### PR TITLE
Django admin search for tags should be case insensitive

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -70,7 +70,7 @@ class TagAdmin(admin.ModelAdmin):
         search_term = search_term.strip()
         if search_term:
             return (
-                queryset.filter(tag__startswith=search_term)
+                queryset.filter(tag__istartswith=search_term)
                 .annotate(tag_length=Length("tag"))
                 .order_by("tag_length"),
                 False,


### PR DESCRIPTION
Make the Django admin search for tags case insensitive.

* Modify the `get_search_results` method in the `TagAdmin` class in `blog/admin.py` to use `tag__istartswith=search_term` instead of `tag__startswith=search_term`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/simonw/simonwillisonblog?shareId=2c3643ba-5fc4-4831-9ea8-a9e669f76a47).