### PR TITLE
Fix Markdown in og descriptions

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -286,3 +286,20 @@ class BlogTests(TransactionTestCase):
         self.assertContains(response6, draft_entry.title)
         self.assertContains(response6, draft_blogmark.link_title)
         self.assertContains(response6, draft_quotation.source)
+
+    def test_og_description_strips_markdown(self):
+        blogmark = BlogmarkFactory(commentary="This **has** *markdown*", use_markdown=True)
+        response = self.client.get(blogmark.get_absolute_url())
+        self.assertContains(
+            response,
+            '<meta property="og:description" content="This has markdown"',
+            html=False,
+        )
+
+        note = NoteFactory(body="A note with **bold** text")
+        response2 = self.client.get(note.get_absolute_url())
+        self.assertContains(
+            response2,
+            '<meta property="og:description" content="A note with bold text"',
+            html=False,
+        )

--- a/templates/blogmark.html
+++ b/templates/blogmark.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block card_title %}{{ blogmark.link_title|typography }}{% endblock %}
-{% block card_description %}{{ blogmark.commentary|truncatewords:30 }}{% endblock %}
+{% block card_description %}{{ blogmark.body|striptags|truncatewords:30 }}{% endblock %}
 
 {% block item_content %}
 {% include "_draft_warning.html" %}

--- a/templates/note.html
+++ b/templates/note.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block card_title %}{% if note.title %}{{ note.title }}{% else %}Note on {{ note.created|date:"jS F Y" }}{% endif %}{% endblock %}
-{% block card_description %}{{ note.body|truncatewords:30 }}{% endblock %}
+{% block card_description %}{{ note.body_rendered|striptags|truncatewords:30 }}{% endblock %}
 
 {% load entry_tags %}
 {% block item_content %}


### PR DESCRIPTION
## Summary
- strip Markdown from og description meta tags for notes and blogmarks
- test that Markdown is removed from meta tags

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_683f808fe8888326b9a2ffeb7ac69d79