### PR TITLE
Add newsletter promo to homepage sidebar

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -26,4 +26,5 @@
   <li><a href="{{ entry.get_absolute_url }}">{{ entry }}</a> - {{ entry.created.date }}</li>
 {% endfor %}
 </ul>
+{% include "_sponsor_promo.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- include the monthly newsletter promo in the homepage sidebar

## Testing
- `DATABASE_URL=postgres://testuser:testpass@localhost/simonwillisonblog python manage.py test -v3`

------
https://chatgpt.com/codex/tasks/task_e_6841a9de204c83269ca52666c2ca9da2