### PR TITLE
Add subscribe note to entries feed

### DIFF
--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -58,9 +58,9 @@ class Entries(Base):
 
     def item_description(self, item):
         note = (
-            '<p><em>You are only seeing the entries from my blog. '
-            'Subscribe to <a href="/atom/everything/">/atom/everything/</a> '
-            'to get all of my posts.</em></p>'
+            '<p><em>You are only seeing the long-form articles from my blog. '
+            'Subscribe to <a href="https://simonwillison.net/atom/everything/">/atom/everything/</a> '
+            'to get all of my posts, or take a look at my <a href="https://simonwillison.net/about/#subscribe">other subscription options</a>.</em></p>'
         )
         return item.body + note
 

--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -57,7 +57,12 @@ class Entries(Base):
         return item.title
 
     def item_description(self, item):
-        return item.body
+        note = (
+            '<p><em>You are only seeing the entries from my blog. '
+            'Subscribe to <a href="/atom/everything/">/atom/everything/</a> '
+            'to get all of my posts.</em></p>'
+        )
+        return item.body + note
 
 
 class Blogmarks(Base):

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -287,6 +287,14 @@ class BlogTests(TransactionTestCase):
         self.assertContains(response6, draft_blogmark.link_title)
         self.assertContains(response6, draft_quotation.source)
 
+    def test_entries_feed_includes_subscribe_note(self):
+        EntryFactory()
+        response = self.client.get("/atom/entries/")
+        self.assertIn(
+            "You are only seeing the entries from my blog. Subscribe to",
+            response.content.decode(),
+        )
+
     def test_og_description_strips_markdown(self):
         blogmark = BlogmarkFactory(commentary="This **has** *markdown*", use_markdown=True)
         response = self.client.get(blogmark.get_absolute_url())

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -291,7 +291,7 @@ class BlogTests(TransactionTestCase):
         EntryFactory()
         response = self.client.get("/atom/entries/")
         self.assertIn(
-            "You are only seeing the entries from my blog. Subscribe to",
+            "You are only seeing the",
             response.content.decode(),
         )
 


### PR DESCRIPTION
## Codex prompt

> Add an italic note to the bottom of every item in my /tom/entries/ feed reminding the user that they are only seeing the entries from my blog and they should subscribe to /atom/everything/ to get all of my posts

## Summary
- append note to each item in `/atom/entries/` feed linking to `/atom/everything/`
- test that the feed contains the reminder

## Testing
- `DATABASE_URL=postgres://testuser:testpass@localhost/simonwillisonblog python manage.py test -v2`

------
https://chatgpt.com/codex/tasks/task_e_684c3a3f4a688326848cf1503e3a5871