### PR TITLE
Fix og:description quoting

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -311,3 +311,14 @@ class BlogTests(TransactionTestCase):
             '<meta property="og:description" content="A note with bold text"',
             html=False,
         )
+
+    def test_og_description_escapes_quotes(self):
+        blogmark = BlogmarkFactory(
+            commentary='Fun new "live music model" release', use_markdown=True
+        )
+        response = self.client.get(blogmark.get_absolute_url())
+        self.assertContains(
+            response,
+            '<meta property="og:description" content="Fun new &quot;live music model&quot; release"',
+            html=False,
+        )

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -322,3 +322,41 @@ class BlogTests(TransactionTestCase):
             '<meta property="og:description" content="Fun new &quot;live music model&quot; release"',
             html=False,
         )
+
+    def test_og_description_escapes_quotes_entry(self):
+        entry = EntryFactory(body='<p>Entry with "quotes" in it</p>')
+        response = self.client.get(entry.get_absolute_url())
+        self.assertContains(
+            response,
+            '<meta property="og:description" content="Entry with “quotes” in it"',
+            html=False,
+        )
+
+    def test_og_description_escapes_quotes_note(self):
+        note = NoteFactory(body='Note with "quotes" inside')
+        response = self.client.get(note.get_absolute_url())
+        self.assertContains(
+            response,
+            '<meta property="og:description" content="Note with &quot;quotes&quot; inside"',
+            html=False,
+        )
+
+    def test_og_description_escapes_quotes_quotation(self):
+        quotation = QuotationFactory(quotation='A "quoted" statement', source='Someone')
+        response = self.client.get(quotation.get_absolute_url())
+        self.assertContains(
+            response,
+            '<meta property="og:description" content="A &quot;quoted&quot; statement"',
+            html=False,
+        )
+
+    def test_og_description_escapes_quotes_tag_page(self):
+        tag = Tag.objects.create(tag='test', description='Tag with "quotes"')
+        entry = EntryFactory()
+        entry.tags.add(tag)
+        response = self.client.get('/tags/test/')
+        self.assertContains(
+            response,
+            '<meta property="og:description" content="1 posts tagged ‘test’. Tag with &quot;quotes&quot;"',
+            html=False,
+        )

--- a/templates/archive_tag.html
+++ b/templates/archive_tag.html
@@ -5,7 +5,7 @@
 {% block extrahead %}
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Simon Willison on {{ tags|join:" and " }}" />
-<meta property="og:description" content="{{ total|intcomma }} posts tagged ‘{{ tags|join:"’ and ‘" }}’. {{ tag.description_rendered|striptags|truncatechars:160 }}" />
+<meta property="og:description" content="{{ total|intcomma }} posts tagged ‘{{ tags|join:"’ and ‘" }}’. {{ tag.description_rendered|striptags|truncatechars:160|force_escape }}" />
 <meta property="og:site_name" content="Simon Willison’s Weblog" />
 {% endblock %}
 

--- a/templates/blogmark.html
+++ b/templates/blogmark.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block card_title %}{{ blogmark.link_title|typography }}{% endblock %}
-{% block card_description %}{{ blogmark.body|striptags|truncatewords:30 }}{% endblock %}
+{% block card_description %}{{ blogmark.body|striptags|truncatewords:30|force_escape }}{% endblock %}
 
 {% block item_content %}
 {% include "_draft_warning.html" %}

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block card_title %}{{ entry.title|typography }}{% endblock %}
-{% block card_description %}{{ entry.body|xhtml|remove_context_paragraph|typography|xhtml2html|striptags|truncatewords:30 }}{% endblock %}
+{% block card_description %}{{ entry.body|xhtml|remove_context_paragraph|typography|xhtml2html|striptags|truncatewords:30|force_escape }}{% endblock %}
 
 {% block item_content %}
 <div data-permalink-context="{{ entry.get_absolute_url }}">

--- a/templates/note.html
+++ b/templates/note.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block card_title %}{% if note.title %}{{ note.title }}{% else %}Note on {{ note.created|date:"jS F Y" }}{% endif %}{% endblock %}
-{% block card_description %}{{ note.body_rendered|striptags|truncatewords:30 }}{% endblock %}
+{% block card_description %}{{ note.body_rendered|striptags|truncatewords:30|force_escape }}{% endblock %}
 
 {% load entry_tags %}
 {% block item_content %}

--- a/templates/quotation.html
+++ b/templates/quotation.html
@@ -3,7 +3,7 @@
 {% block title %}A quote from {{ quotation.source }}{% endblock %}
 
 {% block card_title %}A quote from {{ quotation.source }}{% endblock %}
-{% block card_description %}{{ quotation.body_strip_tags|truncatewords:30 }}{% endblock %}
+{% block card_description %}{{ quotation.body_strip_tags|truncatewords:30|force_escape }}{% endblock %}
 
 {% load entry_tags %}
 {% block item_content %}

--- a/templates/wide.html
+++ b/templates/wide.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block card_title %}{{ entry.title|typography }}{% endblock %}
-{% block card_description %}{{ entry.body|xhtml|remove_context_paragraph|typography|xhtml2html|striptags|truncatewords:30 }}{% endblock %}
+{% block card_description %}{{ entry.body|xhtml|remove_context_paragraph|typography|xhtml2html|striptags|truncatewords:30|force_escape }}{% endblock %}
 
 {% block item_content %}
 <h2>{{ entry.title|typography }}</h2>


### PR DESCRIPTION
## Summary
- escape double quotes in blogmark Open Graph description
- test that quotes are correctly escaped

## Testing
- `python manage.py test -v3`

------
https://chatgpt.com/codex/tasks/task_e_685614e552ec8326ba9479ef068e858d