### PR TITLE
Add top tags page

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -362,3 +362,18 @@ class BlogTests(TransactionTestCase):
             '<meta property="og:description" content="1 posts tagged ‘test’. Tag with &quot;quotes&quot;"',
             html=False,
         )
+
+    def test_top_tags_page(self):
+        for i in range(1, 12):
+            tag = Tag.objects.create(tag=f"tag{i}")
+            for j in range(i):
+                entry = EntryFactory(title=f"Entry{i}-{j}")
+                entry.tags.add(tag)
+        response = self.client.get("/top-tags/")
+        assert response.status_code == 200
+        tags_info = response.context["tags_info"]
+        self.assertEqual(len(tags_info), 10)
+        self.assertEqual(tags_info[0]["tag"].tag, "tag11")
+        self.assertFalse(any(info["tag"].tag == "tag1" for info in tags_info))
+        latest = Tag.objects.get(tag="tag11").entry_set.order_by("-created")[0].title
+        self.assertContains(response, latest)

--- a/config/urls.py
+++ b/config/urls.py
@@ -147,6 +147,7 @@ urlpatterns = [
     re_path(r"^favicon\.ico$", favicon_ico),
     re_path(r"^search/$", search_views.search),
     re_path(r"^about/$", blog_views.about),
+    path("top-tags/", blog_views.top_tags),
     re_path(r"^tags/$", blog_views.tag_index),
     re_path(r"^tags/(.*?)/$", blog_views.archive_tag),
     re_path(r"^tags/(.*?).atom$", blog_views.archive_tag_atom),

--- a/templates/top_tags.html
+++ b/templates/top_tags.html
@@ -1,0 +1,15 @@
+{% extends "smallhead.html" %}
+{% block title %}Top tags{% endblock %}
+{% block primary %}
+<h2 class="archive-h2">Top tags</h2>
+{% for info in tags_info %}
+<h3><a href="{{ info.tag.get_absolute_url }}">{{ info.tag.tag }}</a> ({{ info.total }})</h3>
+<ul>
+  {% for entry in info.recent_entries %}
+  <li><a href="{{ entry.get_absolute_url }}">{{ entry.title }}</a></li>
+  {% empty %}
+  <li>No entries yet</li>
+  {% endfor %}
+</ul>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a `/top-tags/` page listing the ten most popular tags
- display the five most recent entry headlines for each tag
- test the new route and page logic

## Testing
- `DATABASE_URL=postgres://testuser:testpass@localhost/simonwillisonblog python manage.py test -v2`

------
https://chatgpt.com/codex/tasks/task_e_685eeb5f26d483268d47794e0e769951