### PR TITLE
Increase TTL for older posts

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -14,6 +14,7 @@ from django.core.paginator import (
 )
 from django.http import Http404, HttpResponsePermanentRedirect as Redirect, HttpResponse
 from django.test import Client
+from django.utils import timezone
 from .models import (
     Blogmark,
     Entry,
@@ -133,6 +134,10 @@ def archive_item(request, year, month, day, slug):
         )
         if obj.is_draft:
             set_no_cache(response)
+        else:
+            six_months = datetime.timedelta(days=180)
+            if obj.created < timezone.now() - six_months:
+                response["Cache-Control"] = "s-maxage={}".format(24 * 60 * 60)
         response["x-enable-card"] = "1"
         return response
 


### PR DESCRIPTION
## Summary
- set 24 hour Cache-Control header for posts older than six months
- test TTL behavior for old and new items

## Testing
- `DATABASE_URL=postgres://testuser:testpass@localhost/simonwillisonblog python manage.py test -v2 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_686c5320b124832690bd7094dd8218d5

Transcript: https://chatgpt.com/s/cd_686c56123ff48191b7bea5c066cd8474