### PR TITLE
Add frontend admin edit links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -64,8 +64,24 @@ document.addEventListener('DOMContentLoaded', () => {
       if (js) {
         await import(js);
       }
-    }
   }
+}
+</script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.localStorage.getItem('ADMIN')) {
+      document.querySelectorAll('.edit-page-link').forEach(el => {
+        const url = el.getAttribute('data-admin-url');
+        if (url) {
+          const a = document.createElement('a');
+          a.href = url;
+          a.innerText = 'Edit this page';
+          el.appendChild(a);
+          el.style.display = 'block';
+        }
+      });
+    }
+  });
 </script>
 </body>
 </html>

--- a/templates/blogmark.html
+++ b/templates/blogmark.html
@@ -16,6 +16,7 @@
 <p><strong><a href="{{ blogmark.link_url }}">{{ blogmark.link_title }}</a></strong>{% if blogmark.via_url %} (<a href="{{ blogmark.via_url }}" title="{{ blogmark.via_title }}">via</a>){% endif %}{% if not blogmark.via_url and not blogmark.link_title|ends_with_punctuation %}.{% endif %} {% if not blogmark.use_markdown %}{{ blogmark.commentary|typography|linebreaks|strip_wrapping_p }}{% else %}{{ blogmark.body|strip_wrapping_p }}{% endif %}</p>
 
 <div class="entryFooter">Posted <a href="/{{ blogmark.created|date:"Y/M/j/" }}">{{ blogmark.created|date:"jS F Y" }}</a> at {{ blogmark.created|date:"f A"|lower }}</div>
+<p class="edit-page-link" data-admin-url="{{ blogmark.edit_url }}" style="display: none;"></p>
 {% endblock %}
 
 {% block secondary %}

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -27,6 +27,7 @@
 {% endif %}
 </div>
 <div class="entryFooter">Posted <a href="/{{ entry.created|date:"Y/M/j/" }}">{{ entry.created|date:"jS F Y" }}</a> at {{ entry.created|date:"f A"|lower }} &middot; Follow me on <a href="https://fedi.simonwillison.net/@simon">Mastodon</a>, <a href="https://bsky.app/profile/simonwillison.net">Bluesky</a>, <a href="https://twitter.com/simonw">Twitter</a> or <a href="https://simonwillison.net/about/#subscribe">subscribe to my newsletter</a></div>
+<p class="edit-page-link" data-admin-url="{{ entry.edit_url }}" style="display: none;"></p>
 {% endblock %}
 
 {% block recent_articles_header %}More recent articles{% endblock %}

--- a/templates/note.html
+++ b/templates/note.html
@@ -18,6 +18,7 @@
 </div>
 
 <div class="entryFooter">Posted <a href="/{{ note.created|date:"Y/M/j/" }}">{{ note.created|date:"jS F Y" }}</a> at {{ note.created|date:"f A"|lower }}</div>
+<p class="edit-page-link" data-admin-url="{{ note.edit_url }}" style="display: none;"></p>
 {% endblock %}
 
 {% block secondary %}

--- a/templates/quotation.html
+++ b/templates/quotation.html
@@ -14,6 +14,7 @@
 </div>
 
 <div class="entryFooter">Posted <a href="/{{ quotation.created|date:"Y/M/j/" }}">{{ quotation.created|date:"jS F Y" }}</a> at {{ quotation.created|date:"f A"|lower }}</div>
+<p class="edit-page-link" data-admin-url="{{ quotation.edit_url }}" style="display: none;"></p>
 {% endblock %}
 
 {% block secondary %}


### PR DESCRIPTION
## Summary
- add hidden edit link placeholders to item templates
- reveal admin links via JS when localStorage key `ADMIN` is set

## Testing
- `python manage.py test -v3`

------
https://chatgpt.com/codex/tasks/task_e_686d481277188326b18be273f15840d7