### PR TITLE
Use full month names in search results

### DIFF
--- a/blog/search.py
+++ b/blog/search.py
@@ -1,6 +1,7 @@
 import time
 import json
 import re
+import calendar
 from django.db import models
 from django.db.models.functions import TruncYear, TruncMonth
 from django.contrib.postgres.search import SearchQuery, SearchRank
@@ -8,7 +9,6 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.http import HttpResponse, Http404
 from django.shortcuts import render
 from blog.models import Entry, Blogmark, Quotation, Note, Tag, load_mixed_objects
-from .views import MONTHS_3_REV_REV
 from spellchecker import SpellChecker
 import datetime
 
@@ -234,9 +234,11 @@ def search(request, q=None, return_context=False):
         "year": selected_year,
         "month": selected_month,
         "type": selected_type,
-        "month_name": MONTHS_3_REV_REV.get(
-            selected_month and int(selected_month) or "", ""
-        ).title(),
+        "month_name": (
+            calendar.month_name[int(selected_month)]
+            if selected_month.isdigit()
+            else ""
+        ),
         "from_date": from_date,
         "to_date": to_date,
     }

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -392,3 +392,17 @@ class BlogTests(TransactionTestCase):
         self.assertFalse(any(info["tag"].tag == "tag1" for info in tags_info))
         latest = Tag.objects.get(tag="tag11").entry_set.order_by("-created")[0].title
         self.assertContains(response, latest)
+
+    def test_search_title_displays_full_month_name(self):
+        tag = Tag.objects.create(tag="llm-release")
+        entry = EntryFactory(
+            created=datetime.datetime(2025, 7, 1, tzinfo=datetime.timezone.utc)
+        )
+        entry.tags.add(tag)
+        response = self.client.get(
+            "/search/?tag=llm-release&year=2025&month=7"
+        )
+        self.assertContains(
+            response,
+            "Posts tagged llm-release in July, 2025",
+        )


### PR DESCRIPTION
## Summary
- Show full month names in search result titles
- Add regression test for full month name display

## Testing
- `DATABASE_URL=postgres://testuser:testpass@localhost/simonwillisonblog python manage.py test -v3`

------
https://chatgpt.com/codex/tasks/task_e_688be6e0d89883269945cfbe732bc745

Public share link: https://chatgpt.com/s/cd_688beaf58ad481918463729cea55a0f0