### PR TITLE
Add custom admin index template with links to admin tools

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,0 +1,20 @@
+{% extends "admin/index.html" %}
+
+{% block content %}
+{{ block.super }}
+
+<div id="admin-tools" style="margin-top: 20px; padding: 15px; background: #f8f8f8; border: 1px solid #ddd; border-radius: 4px;">
+    <h2 style="margin-top: 0;">Admin Tools</h2>
+    <ul style="list-style: none; padding: 0; margin: 0;">
+        <li style="margin-bottom: 8px;">
+            <a href="/admin/bulk-tag/">Bulk Tag Tool</a> - Add tags to multiple items at once
+        </li>
+        <li style="margin-bottom: 8px;">
+            <a href="/admin/merge-tags/">Merge Tags</a> - Merge multiple tags into one
+        </li>
+        <li style="margin-bottom: 8px;">
+            <a href="/dashboard/">SQL Dashboard</a> - Run SQL queries against the database
+        </li>
+    </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
Adds links at the bottom of the Django admin index page to:
- Bulk Tag Tool (/admin/bulk-tag/)
- Merge Tags (/admin/merge-tags/)
- SQL Dashboard (/dashboard/)

----

> Use a custom admin index page template to add links at the bottom of the admin UI to the /admin/bulk-tag/ and /admin/merge-tags/ and /dashboard/ tools