### PR TITLE
Fix TagMerge admin change page 500 error

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -156,7 +156,7 @@ class TagMergeAdmin(admin.ModelAdmin):
 
     def details_formatted(self, obj):
         """Display the details JSON in a formatted way."""
-        from django.utils.html import format_html
+        from django.utils.html import escape, mark_safe
 
         if not obj.details:
             return "-"
@@ -165,13 +165,14 @@ class TagMergeAdmin(admin.ModelAdmin):
         html_parts = ["<div style='font-family: monospace;'>"]
 
         for content_type, data in details.items():
+            escaped_type = escape(content_type)
             # Handle new format with added/already_tagged
             if isinstance(data, dict) and "added" in data:
                 added = data.get("added", [])
                 already = data.get("already_tagged", [])
                 total = len(added) + len(already)
                 if total:
-                    html_parts.append(f"<p><strong>{content_type}:</strong> {total} item(s)")
+                    html_parts.append(f"<p><strong>{escaped_type}:</strong> {total} item(s)")
                     if added:
                         html_parts.append(
                             f"<br><small>Tag added ({len(added)}): "
@@ -186,12 +187,12 @@ class TagMergeAdmin(admin.ModelAdmin):
             # Handle old format (list of pks) for backwards compatibility
             elif isinstance(data, list) and data:
                 html_parts.append(
-                    f"<p><strong>{content_type}:</strong> {len(data)} item(s)<br>"
+                    f"<p><strong>{escaped_type}:</strong> {len(data)} item(s)<br>"
                     f"<small>IDs: {', '.join(str(pk) for pk in data)}</small></p>"
                 )
 
         html_parts.append("</div>")
-        return format_html("".join(html_parts))
+        return mark_safe("".join(html_parts))
 
     details_formatted.short_description = "Merge Details"
 

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -675,3 +675,28 @@ class MergeTagsTests(TransactionTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Source tag &#x27;nonexistent&#x27; not found")
+
+    def test_tag_merge_admin_change_page(self):
+        """The TagMerge admin change page should load without errors."""
+        # Create a superuser for admin access
+        superuser = User.objects.create_superuser(
+            username="admin", password="adminpass", email="admin@example.com"
+        )
+
+        # Create a TagMerge record directly
+        dest_tag = Tag.objects.create(tag="dest-tag")
+        merge_record = TagMerge.objects.create(
+            source_tag_name="source-tag",
+            destination_tag=dest_tag,
+            destination_tag_name="dest-tag",
+            details={
+                "entries": {"added": [1, 2], "already_tagged": []},
+                "blogmarks": {"added": [], "already_tagged": [3]},
+            },
+        )
+
+        self.client.login(username="admin", password="adminpass")
+        response = self.client.get(f"/admin/blog/tagmerge/{merge_record.pk}/change/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "source-tag")
+        self.assertContains(response, "dest-tag")


### PR DESCRIPTION
The details_formatted method was using format_html() without format
arguments, which raises TypeError in Django 6.0. Changed to use
mark_safe() instead, and properly escape user-controlled content
(content_type field names) to prevent XSS vulnerabilities.

Added test to verify the admin change page loads correctly.

----

> After creating a new tag merge visiting /admin/blog/tagmerge/1/change/ (while signed in as an admin user) throws a 500 - add a test for this and then fix it