### PR TITLE
Change admin tools box heading to just 'Tools'

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -6,13 +6,13 @@
 <div id="admin-tools" style="margin-top: 20px; padding: 15px; background: #f8f8f8; border: 1px solid #ddd; border-radius: 4px;">
     <h2 style="margin-top: 0;">Tools</h2>
     <ul style="list-style: none; padding: 0; margin: 0;">
-        <li style="margin-bottom: 8px;">
+        <li style="list-style: none; margin-bottom: 8px;">
             <a href="/admin/bulk-tag/">Bulk Tag Tool</a> - Add tags to multiple items at once
         </li>
-        <li style="margin-bottom: 8px;">
+        <li style="list-style: none; margin-bottom: 8px;">
             <a href="/admin/merge-tags/">Merge Tags</a> - Merge multiple tags into one
         </li>
-        <li style="margin-bottom: 8px;">
+        <li style="list-style: none; margin-bottom: 8px;">
             <a href="/dashboard/">SQL Dashboard</a> - Run SQL queries against the database
         </li>
     </ul>


### PR DESCRIPTION
Simplify the heading text from 'Admin Tools' to 'Tools'.

> Style the recently added admin tools box (see commit history) to not display the bullet points - also change the heading to just Tools