### PR TITLE
Add clickable admin links to tag delete confirmation page

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -643,3 +643,34 @@ def load_mixed_objects(dicts):
             item.original_dict = d
         to_return.append(item)
     return to_return
+
+
+# Monkey-patch the auto-generated ManyToMany through models for tags to provide
+# meaningful __str__ representations with clickable admin links. This improves
+# the Django admin delete confirmation page for tags.
+from django.utils.html import format_html
+
+
+def _make_tag_through_str(field_name, admin_url_name, display_fn):
+    """Create a __str__ method for a tag through model with admin link."""
+
+    def __str__(self):
+        obj = getattr(self, field_name)
+        return format_html(
+            '{}: <a href="/admin/blog/{}/{}/change/">{}</a>',
+            field_name.title(),
+            admin_url_name,
+            obj.pk,
+            display_fn(obj),
+        )
+
+    return __str__
+
+
+for model, field_name, admin_url_name, display_fn in [
+    (Entry, "entry", "entry", lambda o: o.title),
+    (Blogmark, "blogmark", "blogmark", lambda o: o.link_title),
+    (Quotation, "quotation", "quotation", lambda o: o.source),
+    (Note, "note", "note", lambda o: o.body[:50] + "..." if len(o.body) > 50 else o.body),
+]:
+    model.tags.through.__str__ = _make_tag_through_str(field_name, admin_url_name, display_fn)

--- a/claude-run-tests.sh
+++ b/claude-run-tests.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# Script to run tests for the simonwillisonblog project
+# Can be run multiple times without breaking
+
+# Change to project directory
+cd "$(dirname "$0")"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+    echo "Creating virtual environment..."
+    uv venv --python 3.12 .venv
+fi
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Install dependencies (uv pip install is idempotent)
+echo "Installing dependencies..."
+uv pip install -r requirements.txt --quiet
+
+# Start PostgreSQL if not running
+if ! pg_isready -q 2>/dev/null; then
+    echo "Starting PostgreSQL..."
+    sudo service postgresql start
+    sleep 2
+fi
+
+# Set up postgres user password if needed (idempotent)
+sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';" 2>/dev/null || true
+
+# Create test database if it doesn't exist (idempotent)
+sudo -u postgres createdb test_db 2>/dev/null || true
+
+# Set database URL
+export DATABASE_URL=postgres://postgres:postgres@localhost/test_db
+
+# Run migrations (idempotent)
+echo "Running migrations..."
+python manage.py migrate --noinput
+
+# Run tests
+echo "Running tests..."
+python manage.py test "$@"


### PR DESCRIPTION
Monkey-patch the auto-generated ManyToMany through models for tags to
display meaningful content titles with clickable admin links instead of
generic "Entry_tags object (123)" text. This improves the UX when
reviewing what content will be affected before deleting a tag.

Also adds claude-run-tests.sh for running tests in this environment.

