### PR TITLE
Add toggle for edit page link in Django admin

### DIFF
--- a/static/css/all.css
+++ b/static/css/all.css
@@ -1583,3 +1583,26 @@ div.ea-placement a:link {
   height: 18px;
   fill: currentColor;
 }
+
+/* Edit page link */
+.edit-page-link {
+  margin-top: 0.5em;
+}
+a.edit-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8em;
+  padding: 3px 8px;
+  background-color: var(--color-purple-light);
+  border: 1px solid var(--color-purple-border);
+  border-radius: 4px;
+  color: var(--color-text);
+  text-decoration: none;
+}
+a.edit-link:hover {
+  background-color: var(--color-purple-hover);
+}
+a.edit-link svg {
+  flex-shrink: 0;
+}

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -15,7 +15,26 @@
           <li style="margin-bottom: 8px; list-style: none;">
               <a href="/dashboard/">SQL Dashboard</a> - Run SQL queries against the database
           </li>
+          <li style="margin-bottom: 8px; list-style: none;">
+              <label style="cursor: pointer;">
+                  <input type="checkbox" id="admin-edit-links-toggle" style="margin-right: 6px;">
+                  Show "Edit" links on public pages
+              </label>
+          </li>
       </ul>
   </div>
 </div>
+<script>
+(function() {
+    const toggle = document.getElementById('admin-edit-links-toggle');
+    toggle.checked = !!localStorage.getItem('ADMIN');
+    toggle.addEventListener('change', function() {
+        if (this.checked) {
+            localStorage.setItem('ADMIN', '1');
+        } else {
+            localStorage.removeItem('ADMIN');
+        }
+    });
+})();
+</script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -94,7 +94,8 @@ for (const {tag, js, css} of config) {
         if (url) {
           const a = document.createElement('a');
           a.href = url;
-          a.innerText = 'Edit this page';
+          a.className = 'edit-link';
+          a.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg> Edit';
           el.appendChild(a);
           el.style.display = 'block';
         }


### PR DESCRIPTION
> Make the injected "Edit this page" link look neater. Add a toggle to the custom block of extra links on the Django admin index page which lets me toggle that localStorage option on and off

- Style the "Edit" link with a pencil icon, pill-shaped button appearance
- Add checkbox toggle in admin index Tools section to enable/disable the localStorage ADMIN setting that controls Edit link visibility

https://gistpreview.github.io/?4ea99649864a55f94423e47335155748/index.html