### PR TITLE
Change random button icon from shuffle to dice

### DIFF
--- a/templates/archive_tag.html
+++ b/templates/archive_tag.html
@@ -37,11 +37,12 @@
     {% if total > 5 %}
     <a class="random-post-link" href="/random/{{ tags.0 }}/" id="random-tag-link" data-tag="{{ tags.0 }}">
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="16 3 21 3 21 8"></polyline>
-            <line x1="4" y1="20" x2="21" y2="3"></line>
-            <polyline points="21 16 21 21 16 21"></polyline>
-            <line x1="15" y1="15" x2="21" y2="21"></line>
-            <line x1="4" y1="4" x2="9" y2="9"></line>
+            <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+            <circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" stroke="none"></circle>
+            <circle cx="15.5" cy="8.5" r="1.5" fill="currentColor" stroke="none"></circle>
+            <circle cx="8.5" cy="15.5" r="1.5" fill="currentColor" stroke="none"></circle>
+            <circle cx="15.5" cy="15.5" r="1.5" fill="currentColor" stroke="none"></circle>
+            <circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"></circle>
         </svg>
         Random
     </a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -122,7 +122,7 @@ for (const {tag, js, css} of config) {
     const btn = document.createElement('a');
     btn.href = '/random/' + encodeURIComponent(data.tag) + '/';
     btn.className = 'random-tag-nav';
-    btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 3 21 3 21 8"></polyline><line x1="4" y1="20" x2="21" y2="3"></line><polyline points="21 16 21 21 16 21"></polyline><line x1="15" y1="15" x2="21" y2="21"></line><line x1="4" y1="4" x2="9" y2="9"></line></svg> Random ' + data.tag;
+    btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"></rect><circle cx="8.5" cy="8.5" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="15.5" cy="8.5" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="8.5" cy="15.5" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="15.5" cy="15.5" r="1.5" fill="currentColor" stroke="none"></circle><circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none"></circle></svg> Random ' + data.tag;
 
     btn.addEventListener('click', function(e) {
       // Bump the timestamp before navigating


### PR DESCRIPTION
> Change the icon on the random buttons - on the tag place and sometimes shown in the header - to be a dice icon instead

Replace the shuffle/arrows icon on random buttons with a 5-dot dice
icon to better represent randomness. Updated in both the tag page
and the header navigation button.