### PR TITLE
EthicalAds uses adaptive color scheme

### DIFF
--- a/static/css/all.css
+++ b/static/css/all.css
@@ -136,7 +136,8 @@ cog.outl("}")
 cog.outl("")
 cog.outl(f"{comment_start} Auto dark theme based on system preference (only when no explicit theme is set) {comment_end}")
 cog.outl("@media (prefers-color-scheme: dark) {")
-cog.outl("  :root:not([data-theme]) {")
+cog.outl("  :root:not([data-theme]),")
+cog.outl("  :root[data-theme='auto'] {")
 output_vars("    ")
 cog.outl("  }")
 cog.outl("}")
@@ -199,7 +200,8 @@ cog.outl("}")
 
 /* Auto dark theme based on system preference (only when no explicit theme is set) */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) {
+  :root:not([data-theme]),
+  :root[data-theme='auto'] {
     --color-bg: #1a1a2e;
     --color-text: #e8e8e8;
     --color-text-muted: #a0a0a0;

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,10 +15,8 @@
 {% block extrahead %}{% endblock %}
 <script>
 (function() { // Apply theme immediately to prevent flash
-  const theme = localStorage.getItem('theme');
-  if (theme === 'light' || theme === 'dark') {
-    document.documentElement.setAttribute('data-theme', theme);
-  }
+  const theme = localStorage.getItem('theme') || 'auto';
+  document.documentElement.setAttribute('data-theme', theme);
 })();
 </script>
 </head>
@@ -159,13 +157,8 @@ for (const {tag, js, css} of config) {
   }
 
   function setTheme(theme) {
-    if (theme === 'auto') {
-      localStorage.removeItem('theme');
-      document.documentElement.removeAttribute('data-theme');
-    } else {
-      localStorage.setItem('theme', theme);
-      document.documentElement.setAttribute('data-theme', theme);
-    }
+    localStorage.setItem('theme', theme);
+    document.documentElement.setAttribute('data-theme', theme);
     updateIcon(theme);
   }
 

--- a/templates/blogmark.html
+++ b/templates/blogmark.html
@@ -24,8 +24,8 @@
 
 {% include "_tags.html" with obj=blogmark %}
 
-<div data-ea-publisher="simonwillisonnet" data-ea-type="text"></div>
+<div class="adaptive-css" data-ea-publisher="simonwillisonnet" data-ea-type="text"></div>
 {% include "_sponsor_promo.html" %}
-  
+
 </div> <!-- .metabox -->
 {% endblock %}

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -57,7 +57,7 @@
 {% with entry.previous_by_created as previous_entry %}{% if previous_entry %}
 <p><strong>Previous:</strong> <a href="{{ previous_entry.get_absolute_url }}">{{ previous_entry.title }}</a></p>
 {% endif %}{% endwith %}
-<div data-ea-publisher="simonwillisonnet" data-ea-type="image"></div>
+<div class="adaptive-css" data-ea-publisher="simonwillisonnet" data-ea-type="image"></div>
 {% include "_sponsor_promo.html" %}
 </div>
 

--- a/templates/note.html
+++ b/templates/note.html
@@ -25,7 +25,7 @@
 <div class="metabox">
 {% include "_tags.html" with obj=note %}
 
-<div data-ea-publisher="simonwillisonnet" data-ea-type="text"></div>
+<div class="adaptive-css" data-ea-publisher="simonwillisonnet" data-ea-type="text"></div>
 {% include "_sponsor_promo.html" %}
 
 </div> <!-- .metabox -->


### PR DESCRIPTION
I noticed that the blog started using an adaptive color scheme, but the ads looked off in dark mode. The ad client supports an adaptive color scheme:
https://ethical-ad-client.readthedocs.io/en/latest/#adaptive-color-scheme.

This will work correctly in dark, light and auto mode. However, it required a small change to work in auto mode. To detect that the site uses an adaptive color scheme in auto mode, it needs to set `data-theme=auto`. Instead, your blog was removing `data-theme` when in auto mode. This change makes the site set `data-theme=auto` and the CSS will look for that or fallback to `data-theme` being unset which is what users with JS disabled will get.