### PR TITLE
Add Atom feeds for quotations and notes, with feed icons on listing pages

### DIFF
--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -82,6 +82,41 @@ class Blogmarks(Base):
         return item.title or item.link_title
 
 
+class Quotations(Base):
+    title = "Simon Willison's Weblog: Quotations"
+    description_template = "feeds/quotation.html"
+    ga_source = "quotations"
+
+    def items(self):
+        return (
+            Quotation.objects.filter(is_draft=False)
+            .prefetch_related("tags")
+            .order_by("-created")[:15]
+        )
+
+    def item_title(self, item):
+        return "Quoting %s" % item.source
+
+
+class Notes(Base):
+    title = "Simon Willison's Weblog: Notes"
+    description_template = "feeds/note.html"
+    ga_source = "notes"
+
+    def items(self):
+        return (
+            Note.objects.filter(is_draft=False)
+            .prefetch_related("tags")
+            .order_by("-created")[:15]
+        )
+
+    def item_title(self, item):
+        if item.title:
+            return item.title
+        else:
+            return "Note on {}".format(date_format(item.created, "jS F Y"))
+
+
 class Everything(Base):
     title = "Simon Willison's Weblog"
     description_template = "feeds/everything.html"

--- a/blog/search.py
+++ b/blog/search.py
@@ -310,11 +310,20 @@ def search(request, q=None, return_context=False):
         return render(request, "search.html", context)
 
 
+FEED_URLS = {
+    "entry": "/atom/entries/",
+    "blogmark": "/atom/links/",
+    "quotation": "/atom/quotations/",
+    "note": "/atom/notes/",
+}
+
+
 def type_listing(request, type_name):
     request.GET = request.GET.copy()
     request.GET["type"] = type_name
     context = search(request, return_context=True)
     context["fixed_type"] = True
+    context["feed_url"] = FEED_URLS.get(type_name)
     return render(request, "search.html", context)
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -174,6 +174,8 @@ urlpatterns = [
     re_path(r"^series/(.*?).atom$", blog_views.archive_series_atom),
     re_path(r"^atom/entries/$", count_subscribers(feeds.Entries().__call__)),
     re_path(r"^atom/links/$", count_subscribers(feeds.Blogmarks().__call__)),
+    re_path(r"^atom/quotations/$", count_subscribers(feeds.Quotations().__call__)),
+    re_path(r"^atom/notes/$", count_subscribers(feeds.Notes().__call__)),
     re_path(r"^atom/everything/$", count_subscribers(feeds.Everything().__call__)),
     re_path(r"^sitemap\.xml$", feeds.sitemap),
     path("tools/", blog_views.tools),

--- a/templates/search.html
+++ b/templates/search.html
@@ -6,6 +6,29 @@
 
 {% block item_content %}
 {% load blog_tags %}
+{% if feed_url %}<a style="float: right; border-bottom: none; margin-top: 0.4em" href="{{ feed_url }}" title="Atom feed"><svg
+    xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 0 256 256"
+    role="img" aria-labelledby="atomFeedTitle">
+ <title id="atomFeedTitle">Atom feed</title>
+ <defs>
+   <linearGradient id="a" x1=".1" x2=".9" y1=".1" y2=".9">
+     <stop offset="0" stop-color="#E3702D"></stop>
+     <stop offset=".1" stop-color="#EA7D31"></stop>
+     <stop offset=".4" stop-color="#F69537"></stop>
+     <stop offset=".5" stop-color="#FB9E3A"></stop>
+     <stop offset=".7" stop-color="#EA7C31"></stop>
+     <stop offset=".9" stop-color="#DE642B"></stop>
+     <stop offset="1" stop-color="#D95B29"></stop>
+   </linearGradient>
+ </defs>
+ <rect width="256" height="256" fill="#CC5D15" rx="55" ry="55"></rect>
+ <rect width="246" height="246" x="5" y="5" fill="#F49C52" rx="50" ry="50"></rect>
+ <rect width="236" height="236" x="10" y="10" fill="url(#a)" rx="47" ry="47"></rect>
+ <circle cx="68" cy="189" r="24" fill="#FFF"></circle>
+ <path fill="#FFF" d="M160 213h-34a82 82 0 0 0-82-82V97a116 116 0 0 1 116 116z"></path>
+ <path fill="#FFF" d="M184 213A140 140 0 0 0 44 73V38a175 175 0 0 1 175 175z"></path>
+</svg>
+</a>{% endif %}
 <h2>{{ title }}</h2>
 
 <form action="{% if fixed_type %}/search/{% else %}{{ request.path }}{% endif %}" method="GET">


### PR DESCRIPTION
Previously only entries (/atom/entries/) and links (/atom/links/) had
dedicated feeds. This adds /atom/quotations/ and /atom/notes/ feeds,
and displays feed icon links in the top right of all four type listing
pages (/entries/, /blogmarks/, /quotations/, /notes/).

https://claude.ai/code/session_016PVsiLyvNWZj4vzUQYbu6T