### PR TITLE
Integrate mypy with django-stubs for type checking

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -109,7 +109,7 @@ class BlogmarkAdmin(BaseAdmin):
 @admin.register(Note)
 class NoteAdmin(BaseAdmin):
     search_fields = ("tags__tag", "body")
-    list_display = ("__str__", "created", "tag_summary", "is_draft")
+    list_display = ("__str__", "created", "tag_summary", "is_draft")  # type: ignore[assignment]
 
 
 @admin.register(Tag)
@@ -184,7 +184,8 @@ class TagMergeAdmin(admin.ModelAdmin):
 
     def details_formatted(self, obj):
         """Display the details JSON in a formatted way."""
-        from django.utils.html import escape, mark_safe
+        from django.utils.html import escape
+        from django.utils.safestring import mark_safe
 
         if not obj.details:
             return "-"
@@ -224,7 +225,7 @@ class TagMergeAdmin(admin.ModelAdmin):
         html_parts.append("</div>")
         return mark_safe("".join(html_parts))
 
-    details_formatted.short_description = "Merge Details"
+    details_formatted.short_description = "Merge Details"  # type: ignore[attr-defined]
 
     def has_add_permission(self, request):
         return False

--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -9,6 +9,7 @@ class Base(Feed):
     feed_type = Atom1Feed
     link = "/"
     author_name = "Simon Willison"
+    ga_source = ""
 
     def __call__(self, request, *args, **kwargs):
         response = super(Base, self).__call__(request, *args, **kwargs)
@@ -39,7 +40,7 @@ class Base(Feed):
 
     def get_feed(self, obj, request):
         feedgen = super().get_feed(obj, request)
-        feedgen.content_type = "application/xml; charset=utf-8"
+        feedgen.content_type = "application/xml; charset=utf-8"  # type: ignore[attr-defined]
         return feedgen
 
 

--- a/blog/management/commands/validate_entries_xml.py
+++ b/blog/management/commands/validate_entries_xml.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         for entry in Entry.objects.all():
             try:
-                ElementTree.fromstring("<entry>%s</entry>" % entry.body.encode("utf8"))
+                ElementTree.fromstring("<entry>%s</entry>" % entry.body)
             except Exception as e:
                 print(e)
                 print(entry.title)

--- a/blog/tag_views.py
+++ b/blog/tag_views.py
@@ -81,7 +81,7 @@ def tags_autocomplete(request):
             .order_by("-is_exact_match", "-count", Length("tag"))[:5]
         )
     else:
-        tags = Tag.objects.none()
+        tags = Tag.objects.none()  # type: ignore[assignment]
 
     if request.GET.get("debug"):
         return HttpResponse(

--- a/blog/templatetags/blog_calendar.py
+++ b/blog/templatetags/blog_calendar.py
@@ -66,8 +66,10 @@ MODELS_TO_CHECK = (  # Name, model, score
 
 
 def make_empty_day_dict(date):
-    d = dict([(key, []) for key, _1, _2, _3 in MODELS_TO_CHECK])
-    d.update({"day": date, "populated": False, "display": True})
+    d: dict = dict([(key, []) for key, _1, _2, _3 in MODELS_TO_CHECK])
+    d["day"] = date
+    d["populated"] = False
+    d["display"] = True
     return d
 
 

--- a/blog/templatetags/entry_tags.py
+++ b/blog/templatetags/entry_tags.py
@@ -15,6 +15,8 @@ def xhtml(xhtml):
 
 
 class XhtmlString(object):
+    et: ElementTree.Element
+
     def __init__(self, value, contains_markup=False):
         if isinstance(value, XhtmlString):
             self.et = value.et

--- a/blog/templatetags/tag_cloud.py
+++ b/blog/templatetags/tag_cloud.py
@@ -52,7 +52,7 @@ def tag_cloud_for_tags(tags):
 
 def _tag_cloud_helper(tags):
     # Count them all up
-    tag_counts = {}
+    tag_counts: dict[str, int] = {}
     for tag in tags:
         try:
             tag_counts[tag] += 1

--- a/blog/views_2003.py
+++ b/blog/views_2003.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from django.shortcuts import render
 from django.db.models import CharField, Value
 import datetime
@@ -34,8 +38,8 @@ def index(request):
     )
 
     # Now load the entries, blogmarks, quotations
-    items = []
-    to_load = {}
+    items: list[dict[str, Any]] = []
+    to_load: dict[str, list[Any]] = {}
     for item in recent:
         to_load.setdefault(item["content_type"], []).append(item["id"])
     for content_type, model in (

--- a/config/settings.py
+++ b/config/settings.py
@@ -160,12 +160,12 @@ if "DATABASE_URL" in os.environ:
     # Parse database configuration from $DATABASE_URL
     DATABASES["default"] = dj_database_url.config()
     DATABASES["dashboard"] = dj_database_url.config()
-    DATABASES["dashboard"]["OPTIONS"] = {
+    DATABASES["dashboard"]["OPTIONS"] = {  # type: ignore[index]
         "options": "-c default_transaction_read_only=on -c statement_timeout=3000"
     }
 
 if "DISABLE_AUTOCOMMIT" in os.environ:
-    DATABASES["default"]["AUTOCOMMIT"] = False
+    DATABASES["default"]["AUTOCOMMIT"] = False  # type: ignore[index]
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/config/urls_2003.py
+++ b/config/urls_2003.py
@@ -26,7 +26,7 @@ if settings.DEBUG:
     try:
         import debug_toolbar
 
-        urlpatterns = [
+        urlpatterns = [  # type: ignore[assignment]
             re_path(r"^__debug__/", include(debug_toolbar.urls))
         ] + urlpatterns
     except ImportError:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,116 @@
+[mypy]
+plugins =
+    mypy_django_plugin.main
+
+python_version = 3.11
+strict = false
+
+# Enable useful checks without going full-strict
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+check_untyped_defs = true
+no_implicit_reexport = true
+
+# Django settings module
+mypy_path = .
+
+[mypy.plugins.django-stubs]
+django_settings_module = config.settings
+
+# Exclude auto-generated migrations from type checking
+[mypy-*.migrations.*]
+ignore_errors = true
+
+# Legacy import script uses BeautifulSoup v3
+[mypy-blog.management.commands.import_quora]
+ignore_errors = true
+
+# Test files and factories use factory-boy which doesn't have stubs
+[mypy-blog.factories]
+ignore_errors = true
+
+[mypy-blog.tests]
+ignore_errors = true
+
+[mypy-blog.tests.*]
+ignore_errors = true
+
+[mypy-monthly.tests]
+ignore_errors = true
+
+[mypy-monthly.tests.*]
+ignore_errors = true
+
+[mypy-feedstats.tests]
+ignore_errors = true
+
+[mypy-feedstats.tests.*]
+ignore_errors = true
+
+[mypy-redirects.tests]
+ignore_errors = true
+
+[mypy-redirects.tests.*]
+ignore_errors = true
+
+# Third-party libraries without stubs
+[mypy-arrow.*]
+ignore_missing_imports = true
+
+[mypy-cloudflare.*]
+ignore_missing_imports = true
+
+[mypy-pytz.*]
+ignore_missing_imports = true
+
+[mypy-dj_database_url.*]
+ignore_missing_imports = true
+
+[mypy-djp.*]
+ignore_missing_imports = true
+
+[mypy-factory.*]
+ignore_missing_imports = true
+
+[mypy-spellchecker.*]
+ignore_missing_imports = true
+
+[mypy-debug_toolbar.*]
+ignore_missing_imports = true
+
+[mypy-raven.*]
+ignore_missing_imports = true
+
+[mypy-proxy.*]
+ignore_missing_imports = true
+
+[mypy-django_sql_dashboard.*]
+ignore_missing_imports = true
+
+[mypy-django_hosts.*]
+ignore_missing_imports = true
+
+[mypy-django_http_debug.*]
+ignore_missing_imports = true
+
+[mypy-dateutils.*]
+ignore_missing_imports = true
+
+[mypy-db_to_sqlite.*]
+ignore_missing_imports = true
+
+[mypy-django_plugin_django_header.*]
+ignore_missing_imports = true
+
+[mypy-html5lib.*]
+ignore_missing_imports = true
+
+[mypy-whitenoise.*]
+ignore_missing_imports = true
+
+[mypy-django_proxy.*]
+ignore_missing_imports = true
+
+[mypy-gunicorn.*]
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,10 @@ whitenoise==6.11.0
 Markdown==3.10
 django-hosts==7.0.0
 pyspellchecker==0.8.4
+mypy==1.19.1
+django-stubs==5.2.9
+django-stubs-ext==5.2.9
+types-requests==2.32.4.20260107
+types-Markdown==3.10.2.20260211
+types-beautifulsoup4==4.12.0.20250516
+types-python-dateutil==2.9.0.20260124


### PR DESCRIPTION
Add mypy and django-stubs configuration for static type checking across
the entire codebase. All 93 source files now pass mypy cleanly.

Changes:
- Add mypy.ini with django-stubs plugin configuration
- Add type annotations where needed (imports, variable declarations)
- Fix actual bugs: mark_safe import from wrong module in admin.py,
  bytes-to-string encoding in validate_entries_xml.py
- Add type: ignore comments for Django patterns mypy can't handle
  (admin allow_tags/short_description, GenericForeignKey, monkey-patching)
- Exclude migrations, tests, and legacy import_quora from type checking
- Add mypy, django-stubs, and type stub packages to requirements.txt

https://claude.ai/code/session_01QoB1MehKSA1kvnKxX5MYNv