### PR TITLE
Add ID-based filtering to search and bulk-tag pages

### DIFF
--- a/blog/templatetags/blog_tags.py
+++ b/blog/templatetags/blog_tags.py
@@ -92,6 +92,14 @@ def replace_qsarg(context, name, value):
     return _search_prefix(context, query_dict)
 
 
+@register.simple_tag(takes_context=True)
+def remove_id_filters(context):
+    query_dict = context["request"].GET.copy()
+    for param in ("entries", "blogmarks", "quotations", "notes"):
+        query_dict.pop(param, None)
+    return _search_prefix(context, query_dict)
+
+
 @register.filter
 def markdownify(text):
     """

--- a/templates/bulk_tag.html
+++ b/templates/bulk_tag.html
@@ -131,7 +131,17 @@
             {% endif %}
         {% endfor %}
     {% endif %}
+    {% for param, value in id_filter_params.items %}
+        <input type="hidden" name="{{ param }}" value="{{ value }}">
+    {% endfor %}
 </form>
+
+{% if id_filter_type_names %}
+<p class="id-filter-notice">
+    Filtered to specific {{ id_filter_type_names|join:", " }}
+    <a href="{% remove_id_filters %}" title="Clear filter">&#x00D7;</a>
+</p>
+{% endif %}
 
 {% if total %}
     <div class="tag-input-container">

--- a/templates/search.html
+++ b/templates/search.html
@@ -45,7 +45,17 @@
             {% endif %}
         {% endfor %}
     {% endif %}
+    {% for param, value in id_filter_params.items %}
+        <input type="hidden" name="{{ param }}" value="{{ value }}">
+    {% endfor %}
 </form>
+
+{% if id_filter_type_names %}
+<p class="id-filter-notice">
+    Filtered to specific {{ id_filter_type_names|join:", " }}
+    <a href="{% remove_id_filters %}" title="Clear filter">&#x00D7;</a>
+</p>
+{% endif %}
 
 <p class="search-selections">
     {% if selected %}<span class="filters">
@@ -73,13 +83,13 @@
 <div id="autocomplete-tags" aria-live="polite"></div>
 
 {% if total %}
-    {% if selected or q %}
+    {% if selected or q or id_filters %}
         {% include "_pagination.html" with page_total=total %}
         {% blog_mixed_list_with_dates results %}
         {% include "_pagination.html" %}
     {% endif %}
 {% else %}
-    {% if selected or q %}
+    {% if selected or q or id_filters %}
         <p><strong>No results found</strong></p>
         {% if suggestion and num_corrected_results %}
             <p style="margin: 1em 0">Suggestion: <a href="/search/?q={{ suggestion }}">{{ suggestion }}</a> ({{ num_corrected_results }} result{{ num_corrected_results|pluralize }})</p>


### PR DESCRIPTION
> I want this to work:
> 
> /admin/bulk-tag/?entries=2,4,5&quotations=1,3&notes=4,8&blogmarks=7,9
> 
> This should force the search results to start out as filtered to ONLY the entries/quotations/blogmarks/notes with the specified IDs - then any extra things like &q=blah would search within those filtered items
> 
> If it's more convenient you can make this change to `/search/` and have it carry through to this
> 
> No need to document this anywhere it's an undocumented feature
> 
> Do however show a message at the top of the page that says "Filtered to specific entries, notes" (showing the types that are filtered) with a cross icon to clear that filter
> 
> Run tests first. Use red/green TDD to build this.

## Summary
This PR adds the ability to filter search and bulk-tag results by specific object IDs using query parameters. Users can now pass comma-separated IDs for entries, notes, quotations, and blogmarks to narrow down results to a specific subset of objects.

## Key Changes
- **Search filtering logic**: Added parsing of `entries=`, `notes=`, `quotations=`, and `blogmarks=` query parameters in `search.py`. When ID filters are active, only the specified types are included in results, and querysets are filtered to only include objects with IDs in the provided lists.
- **Template updates**: Modified `search.html` and `bulk_tag.html` to:
  - Preserve ID filter parameters as hidden form fields so filters persist through form submissions
  - Display a filter notice showing which types are currently filtered, with a clear button (×) to remove all ID filters
  - Only show results/pagination when there's an active search query, type selection, or ID filter
- **Template tag**: Added `remove_id_filters()` template tag to generate a URL that clears all ID-based filters while preserving other query parameters
- **Comprehensive test coverage**: Added 15 new tests covering:
  - Filtering by individual and multiple types
  - Combining ID filters with search queries
  - Filter message display and clearing
  - Functionality on both `/admin/bulk-tag/` and `/search/` pages
  - Edge cases like invalid IDs and hidden form field preservation

## Implementation Details
- ID filters are parsed from comma-separated values and validated to ensure they're numeric
- When ID filters are active, types not mentioned in the query parameters are completely excluded from results
- ID filters work in combination with existing search queries (the search term is applied within the filtered ID set)
- The filter notice dynamically lists only the types being filtered, making it clear to users what constraints are active

https://claude.ai/code/session_017yBEkEdPXHJ55hi6PLuLm1