### PR TITLE
Fix pagination display when id_filters are applied

### DIFF
--- a/templates/bulk_tag.html
+++ b/templates/bulk_tag.html
@@ -162,13 +162,13 @@
         </div>
     </div>
 
-    {% if selected or q %}
+    {% if selected or q or id_filters %}
         {% include "_pagination.html" with page_total=total %}
         {{ block.super }}
         {% include "_pagination.html" %}
     {% endif %}
 {% else %}
-    {% if selected or q %}
+    {% if selected or q or id_filters %}
         <p><strong>No results found</strong></p>
         {% if suggestion and num_corrected_results %}
             <p style="margin: 1em 0">Suggestion: <a href="/admin/bulk-tag/?q={{ suggestion }}">{{ suggestion }}</a> ({{ num_corrected_results }} result{{ num_corrected_results|pluralize }})</p>


### PR DESCRIPTION
> Review most recent commit. There's one bug: the /admin/bulk-tag/?entries=1 page won't show the actual content unless there is at least one additional filter applied. This is not true for the /search/?entries=1 page

Refs:
- #588 

## Summary
Updated the bulk tagging template to properly display pagination and results when filtering by ID filters, in addition to the existing checks for selected items and search queries.

## Changes
- Modified two conditional checks in `templates/bulk_tag.html` to include `id_filters` alongside `selected` and `q` parameters
  - Line 165: Updated pagination display condition
  - Line 171: Updated "No results found" message condition

## Details
Previously, the pagination and results sections would only display when users had either selected items (`selected`) or entered a search query (`q`). This change extends that logic to also trigger when ID filters (`id_filters`) are applied, ensuring consistent UI behavior across all filtering methods in the bulk tagging interface.

https://claude.ai/code/session_01TFG1xf8zKjA7GdgxNh74mH