### PR TITLE
Update release importer to handle nested releases structure

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -1516,10 +1516,18 @@ class ImporterViewTests(TransactionTestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "my-repo": {
-                "release": "1.0",
-                "published_at": "2025-01-15T10:00:00Z",
-                "url": "https://github.com/simonw/my-repo/releases/tag/1.0",
                 "description": "First release",
+                "repo": "my-repo",
+                "repo_url": "https://github.com/simonw/my-repo",
+                "total_releases": 1,
+                "releases": [
+                    {
+                        "release": "1.0",
+                        "published_at": "2025-01-15T10:00:00Z",
+                        "published_day": "2025-01-15",
+                        "url": "https://github.com/simonw/my-repo/releases/tag/1.0",
+                    }
+                ],
             }
         }
         mock_response.raise_for_status = MagicMock()
@@ -1571,10 +1579,18 @@ class ImporterViewTests(TransactionTestCase):
         releases = {}
         for i in range(15):
             releases["repo-{}".format(i)] = {
-                "release": "1.0",
-                "published_at": "2025-01-{}T10:00:00Z".format(15 + i),
-                "url": "https://github.com/simonw/repo-{}/releases/tag/1.0".format(i),
                 "description": "",
+                "repo": "repo-{}".format(i),
+                "repo_url": "https://github.com/simonw/repo-{}".format(i),
+                "total_releases": 1,
+                "releases": [
+                    {
+                        "release": "1.0",
+                        "published_at": "2025-01-{}T10:00:00Z".format(15 + i),
+                        "published_day": "2025-01-{}".format(15 + i),
+                        "url": "https://github.com/simonw/repo-{}/releases/tag/1.0".format(i),
+                    }
+                ],
             }
 
         mock_response = MagicMock()


### PR DESCRIPTION
> I changed the format of `https://raw.githubusercontent.com/simonw/simonw/refs/heads/main/releases_cache.json` - look at the new shape and then update the code that uses this endpoint so it imports all of the releases - the old shape looked like https://raw.githubusercontent.com/simonw/simonw/22f805b10ff485794279aef97a23d1e4d00dc518/releases_cache.json

## Summary
Updated the `import_releases` function to handle a new API response structure where release information is nested under a `releases` array within each repository object, rather than being a flat structure at the repository level.

## Key Changes
- **API Response Structure**: Changed from flat repo-level release data to a nested structure where each repo contains a `releases` array
- **Loop Restructuring**: Added an inner loop to iterate through multiple releases per repository
- **Data Extraction**: Moved repository-level `description` outside the inner loop to be shared across all releases from the same repository
- **Field Mapping**: Updated field access to use `release` dict instead of `info` dict for release-specific fields (`published_at`, `url`)
- **Test Updates**: Updated test fixtures in `test_api_run_importer_releases` and `test_api_run_importer_shows_max_10_items` to match the new nested structure, including new fields like `repo`, `repo_url`, `total_releases`, and `published_day`

## Implementation Details
- The repository description is now extracted once per repo and reused for all its releases, improving efficiency
- The import reference format remains unchanged: `"release:{}:{}".format(repo_name, version)`
- The function maintains backward compatibility in terms of return values and Beat object creation

https://claude.ai/code/session_01RLVzy9kJzLFGwRwvcnz4Ff