### PR TITLE
Add Beat model support to blog calendar template tag

### DIFF
--- a/blog/templatetags/blog_calendar.py
+++ b/blog/templatetags/blog_calendar.py
@@ -2,7 +2,7 @@ from django import template
 
 register = template.Library()
 
-from blog.models import Entry, Photo, Quotation, Blogmark, Photoset, Note
+from blog.models import Entry, Photo, Quotation, Blogmark, Photoset, Note, Beat
 import datetime, copy
 
 # This code used to use the following:
@@ -67,6 +67,7 @@ MODELS_TO_CHECK = (  # Name, model, score
 
 def make_empty_day_dict(date):
     d = dict([(key, []) for key, _1, _2, _3 in MODELS_TO_CHECK])
+    d["beats"] = []
     d.update({"day": date, "populated": False, "display": True})
     return d
 
@@ -99,6 +100,13 @@ def calendar_context(date):
             day = day_things[attribute_lookup(item, created_lookup).date()]
             day[name].append(item)
             day["populated"] = True
+    # Also check for beats - they make days linkable but don't affect the score/colour
+    for item in Beat.objects.filter(
+        created__month=date.month, created__year=date.year, is_draft=False
+    ):
+        day = day_things[item.created.date()]
+        day["beats"].append(item)
+        day["populated"] = True
     # Now that we've gathered the data we can render the calendar
     days = list(day_things.values())
     days.sort(key=lambda x: x["day"])


### PR DESCRIPTION
> There's a calendar widget on several pages which links to days that have content. It doesn't link to days that have at least one beat. It should link to days with beats but those beats should not be added to the total that decides the background color of that square - if the day has only beats and nothing else the square in the calendar should remain white but it should still be an active link to that date

## Summary
This change adds support for the `Beat` model in the blog calendar template tag, allowing beat entries to be displayed on the calendar without affecting the day's color/score.

## Key Changes
- Import the `Beat` model from `blog.models`
- Initialize an empty `beats` list in the day dictionary structure
- Add logic to query and populate beat entries for each month, filtering out draft beats
- Mark days containing beats as "populated" to make them linkable, while keeping beats separate from other content types that affect visual styling

## Implementation Details
Beats are handled similarly to other content types but with a key difference: they populate the calendar and make days clickable without contributing to the day's visual score or color (which is determined by the count of other content types). This is achieved by storing beats in a separate list within the day dictionary rather than including them in the `MODELS_TO_CHECK` tuple.

https://claude.ai/code/session_01RFVo9rL1wbw9Ztywux7sDV