### PR TITLE
Remove beats visibility toggle feature

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -69,29 +69,6 @@
   });
 })();
 </script>
-<div id="beats-toggle" style="display:none; background: #f5f3f0; border: 1px solid #ddd; border-radius: 6px; padding: 12px 16px; margin-bottom: 20px;">
-  <label style="cursor: pointer; font-size: 0.9em;">
-    <input type="checkbox" id="beats-checkbox" style="margin-right: 6px;">
-    <strong>Make beats visible across the site</strong>
-  </label>
-</div>
-<script>
-(function() {
-  var show = new URLSearchParams(window.location.search).get('beats') === '1' || localStorage.getItem('show_beats');
-  if (!show) return;
-  var toggle = document.getElementById('beats-toggle');
-  toggle.style.display = '';
-  var checkbox = document.getElementById('beats-checkbox');
-  checkbox.checked = !!localStorage.getItem('show_beats');
-  checkbox.addEventListener('change', function() {
-    if (this.checked) {
-      localStorage.setItem('show_beats', '1');
-    } else {
-      localStorage.removeItem('show_beats');
-    }
-  });
-})();
-</script>
 <div data-permalink-context="/about/">
 <h2>About me</h2>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -196,10 +196,5 @@ for (const {tag, js, css} of config) {
   toggle.addEventListener('click', cycleTheme);
 })();
 </script>
-<script>
-if (localStorage.getItem('show_beats')) {
-  document.querySelectorAll('.beat.segment').forEach(function(el) { el.style.display = ''; });
-}
-</script>
 </body>
 </html>

--- a/templates/includes/blog_mixed_list.html
+++ b/templates/includes/blog_mixed_list.html
@@ -59,7 +59,7 @@
 </div>
 {% endif %}
 {% if item.type == "beat" %}
-<div class="beat segment" data-type="beat" data-id="{{ item.obj.id }}" style="display:none">
+<div class="beat segment" data-type="beat" data-id="{{ item.obj.id }}">
   <div class="beat-row1">
     {% if item.obj.beat_type == "til_update" %}
       <span class="beat-label til-update">TIL<span class="til-update-suffix">(updated)</span></span>

--- a/templates/search.html
+++ b/templates/search.html
@@ -108,12 +108,12 @@
         <h3 id="facet-types">Types</h3>
         <ul>
             {% for t in type_counts %}
-                <li{% if t.type == "beat" %} class="beat-facet" style="display:none"{% endif %}><a href="{% add_qsarg "type" t.type %}">{{ t.type }}</a> {{ t.n|intcomma }}</a></li>
+                <li><a href="{% add_qsarg "type" t.type %}">{{ t.type }}</a> {{ t.n|intcomma }}</a></li>
             {% endfor %}
         </ul>
     {% endif %}
     {% if beat_type_counts %}
-        <div class="beat-facet" style="display:none">
+        <div>
         <h3 id="facet-beat-types">Beats</h3>
         <ul>
             {% for t in beat_type_counts %}
@@ -147,11 +147,6 @@
         </ul>
     {% endif %}
 </div>
-<script>
-if (localStorage.getItem('show_beats')) {
-  document.querySelectorAll('.beat-facet').forEach(function(el) { el.style.display = ''; });
-}
-</script>
 <script>
 function debounce(func, wait) {
   let timeout;


### PR DESCRIPTION
> OK launch the beats thing, ditch the code that hides it unless there in a localStorage key, remove the UI from the /about/ page that lets you toggle it on and off

This PR removes the beats visibility toggle feature that allowed users to show/hide beat content across the site using a localStorage-based preference.

## Summary
The beats toggle functionality has been completely removed from the codebase. This includes the UI toggle control, localStorage persistence logic, and all conditional display logic that showed/hid beat-related content based on user preference.

## Key changes
- Removed the "Make beats visible across the site" toggle UI from the about page template
- Removed localStorage-based show_beats preference handling from multiple templates
- Removed conditional display logic that hid beat facets in search results
- Removed inline `style="display:none"` attributes from beat elements that were controlled by the toggle
- Removed JavaScript code that checked localStorage and toggled beat visibility on page load

## Files modified
- `templates/about.html` - Removed toggle UI and associated JavaScript
- `templates/search.html` - Removed beat facet hiding logic and display toggle script
- `templates/base.html` - Removed global beats visibility script
- `templates/includes/blog_mixed_list.html` - Removed inline display:none style from beat segments

Beats are now always visible by default with no user preference option to hide them.

https://claude.ai/code/session_01ATKzURWJPUf1sCyFhtCgeE