### PR TITLE
Surface beat subtypes in Type facet instead of generic "beat"

### DIFF
--- a/blog/search.py
+++ b/blog/search.py
@@ -248,9 +248,19 @@ def search(request, q=None, return_context=False):
     db_sort = {"relevance": "-rank", "date": "-created"}[sort]
     qs = qs.order_by(db_sort)
 
+    type_labels = {
+        "entry": "Entry",
+        "blogmark": "Blogmark",
+        "quotation": "Quotation",
+        "note": "Note",
+    }
+    # Add beat subtype labels: beat:release -> Release, etc.
+    for bt_value, bt_label in Beat.BeatType.choices:
+        type_labels[f"beat:{bt_value}"] = bt_label
+
     type_counts = sorted(
         [
-            {"type": type_name, "n": value}
+            {"type": type_name, "label": type_labels.get(type_name, type_name), "n": value}
             for type_name, value in list(type_counts_raw.items())
         ],
         key=lambda t: t["n"],
@@ -310,6 +320,7 @@ def search(request, q=None, return_context=False):
         "year": selected_year,
         "month": selected_month,
         "type": selected_type,
+        "type_label": type_labels.get(selected_type, selected_type) if selected_type else "",
         "beat": selected_beat,
         "beat_label": (
             beat_type_labels.get(selected_beat, selected_beat) if selected_beat else ""

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -1507,15 +1507,15 @@ class BeatTypeFacetTests(TransactionTestCase):
         BeatFactory(title="A release", beat_type="release")
         BeatFactory(title="A TIL", beat_type="til_new")
         response = self.client.get("/search/?q=")
-        # The template should display labels for beat subtypes
-        self.assertContains(response, "beat:release")
-        self.assertContains(response, "beat:til_new")
+        # The template should display human-readable labels, not raw beat:* keys
+        self.assertContains(response, ">Release</a>")
+        self.assertContains(response, ">TIL</a>")
 
     def test_selected_type_pill_shows_beat_subtype(self):
-        """When filtering by beat:release, the selected filter pill should show the subtype."""
+        """When filtering by beat:release, the selected filter pill should show the human-readable label."""
         BeatFactory(title="A release", beat_type="release")
         response = self.client.get("/search/?type=beat:release")
-        self.assertContains(response, "Type: beat:release")
+        self.assertContains(response, "Type: Release")
 
     def test_plain_type_beat_still_works(self):
         """?type=beat should still show all beats regardless of subtype."""

--- a/templates/search.html
+++ b/templates/search.html
@@ -61,7 +61,7 @@
     {% if selected %}<span class="filters">
         Filters:
         {% if selected.type and not fixed_type %}
-            <a class="selected-tag" href="{% remove_qsarg "type" selected.type %}">Type: {{ selected.type }} <strong>&#x00D7;</strong></a>
+            <a class="selected-tag" href="{% remove_qsarg "type" selected.type %}">Type: {{ selected.type_label }} <strong>&#x00D7;</strong></a>
         {% endif %}
         {% if selected.year %}
             <a class="selected-tag" href="{% remove_qsarg "year" selected.year %}">Year: {{ selected.year }} <strong>&#x00D7;</strong></a>
@@ -108,7 +108,7 @@
         <h3 id="facet-types">Types</h3>
         <ul>
             {% for t in type_counts %}
-                <li><a href="{% add_qsarg "type" t.type %}">{{ t.type }}</a> {{ t.n|intcomma }}</a></li>
+                <li><a href="{% add_qsarg "type" t.type %}">{{ t.label }}</a> {{ t.n|intcomma }}</a></li>
             {% endfor %}
         </ul>
     {% endif %}


### PR DESCRIPTION
> Currently the search engine presents Beats as a content type and then lets you facet by Beats and then by the type of beats
> 
> Investigate what it would take to instead have those types of Beats surfaced in the type facet directly, so you see Entries, Notes, TILs, Releases all at the same time?type= level
> 
> The query string should be ?type=beat:tils or similar

## Summary
This change enhances the search interface to display beat subtypes (release, til_new, til_update, research, tool) as separate facet options in the Type filter, rather than grouping all beats under a single "beat" category. Users can now filter search results by specific beat types like "beat:release" or "beat:til_new".

## Key Changes

- **Search logic (`blog/search.py`)**:
  - Added parsing of `type=beat:*` parameters to extract the beat subtype
  - Modified type counting to break down beats by their `beat_type` field, creating entries like `beat:release`, `beat:til_new`, etc. in the type counts
  - Updated queryset filtering to support filtering by beat subtype when `type=beat:something` is specified
  - Maintained backward compatibility with `type=beat` to show all beats regardless of subtype
  - Added beat subtype-specific labels for page titles (e.g., "Releases" for `beat:release`)

- **Template (`templates/search.html`)**:
  - Removed the CSS rule that hid the generic "beat" facet option, since it's no longer generated
  - Beat subtypes now display naturally alongside other type facets

- **Tests (`blog/tests.py`)**:
  - Added comprehensive test suite (`BeatTypeFacetTests`) with 11 tests covering:
    - Type facet includes beat subtypes instead of generic "beat"
    - Correct counts for each beat subtype
    - Filtering by specific beat subtypes
    - Human-readable labels in facets and selected filter pills
    - Backward compatibility with `type=beat`
    - Combined filtering with search queries
    - All beat subtypes appearing in type counts
    - Beats listing page still functioning

## Implementation Details

- Beat subtypes are identified using the `beat:` prefix in the type facet (e.g., `beat:release`)
- The implementation uses Django's `annotate()` and `Count()` to efficiently group beats by type
- Page titles dynamically reflect the selected beat subtype using a mapping dictionary
- The change is fully backward compatible—existing `type=beat` filters continue to work

https://claude.ai/code/session_01FzwcZ6zUeiqQ6mnuTmZjow