### PR TITLE
Make images in beat notes responsive with max-width constraint

### DIFF
--- a/static/css/all.css
+++ b/static/css/all.css
@@ -1969,6 +1969,11 @@ div.beat {
   white-space: normal;
 }
 
+.beat-note img {
+  max-width: 100%;
+  height: auto;
+}
+
 .beat-note p {
   margin-bottom: 0.8em;
 }


### PR DESCRIPTION
> Make sure that images inside beats on the hompage and other timelines have max width 100%

## Summary
Added CSS styling to make images within beat notes responsive and properly constrained within their container.

## Key Changes
- Added new `.beat-note img` CSS rule to ensure images scale responsively
- Set `max-width: 100%` to prevent images from overflowing their container
- Set `height: auto` to maintain proper aspect ratio when images are scaled

## Implementation Details
The new styles are positioned before the existing `.beat-note p` rule, ensuring images in beat notes will automatically resize to fit their parent container while preserving their aspect ratio. This prevents layout issues when beat notes contain images of varying sizes.

https://claude.ai/code/session_01GJEM6HcFG2JZ7JykmGfRAW