### PR TITLE
Add link to trigger build workflow in importers template

### DIFF
--- a/templates/importers.html
+++ b/templates/importers.html
@@ -18,6 +18,8 @@
 </div>
 {% endfor %}
 
+<p><a href="https://github.com/simonw/simonw/actions/workflows/build.yml">Trigger build</a></p>
+
 <script>
 document.querySelectorAll('.run-import-btn').forEach(function(btn) {
   btn.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
Added a link to the GitHub Actions build workflow in the importers template page.

## Changes
- Added a new paragraph with a link to the GitHub Actions build workflow (`build.yml`) in the importers template
- The link allows users to manually trigger the build process directly from the importers page

## Implementation Details
- The link points to `https://github.com/simonw/simonw/actions/workflows/build.yml`
- Placed after the importer list loop and before the existing JavaScript code for better visibility

https://claude.ai/code/session_011uY1PeDhu5whGcZa33cpRb