### PR TITLE
Render markdown-copy as <pre> in atom feeds

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -2615,6 +2615,22 @@ class ChapterEverywhereTests(TransactionTestCase):
         response = self.client.get("/atom/everything/")
         self.assertNotContains(response, "Draft Feed Chapter")
 
+    def test_chapter_markdown_copy_fence_in_atom_feed_uses_pre(self):
+        """In atom feeds, ```markdown-copy fences should render as <pre> not <markdown-copy><textarea>."""
+        body = "```markdown-copy\n# Hello\n\nSome **bold** text\n```"
+        self._make_chapter(title="Feed Copy Chapter", body=body)
+        response = self.client.get("/atom/everything/")
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # HTML is XML-escaped inside <summary type="html"> in an atom feed
+        self.assertNotIn("markdown-copy", content)
+        self.assertNotIn("textarea", content)
+        self.assertIn("&lt;pre&gt;", content)
+        self.assertIn("&lt;/pre&gt;", content)
+        # Content should still be present
+        self.assertIn("# Hello", content)
+        self.assertIn("Some **bold** text", content)
+
     def test_chapter_guide_breadcrumb_style(self):
         """Chapter should show guide name with > and no underline."""
         chapter = self._make_chapter()

--- a/guides/models.py
+++ b/guides/models.py
@@ -13,11 +13,23 @@ def _markdown_copy_formatter(source, language, css_class, options, md, **kwargs)
     return f"<div><markdown-copy><textarea>{escape(source)}</textarea></markdown-copy></div>"
 
 
+def _markdown_copy_feed_formatter(source, language, css_class, options, md, **kwargs):
+    return f"<pre>{escape(source)}</pre>"
+
+
 _CUSTOM_FENCES = [
     {
         "name": "markdown-copy",
         "class": "",
         "format": _markdown_copy_formatter,
+    }
+]
+
+_CUSTOM_FENCES_FEED = [
+    {
+        "name": "markdown-copy",
+        "class": "",
+        "format": _markdown_copy_feed_formatter,
     }
 ]
 
@@ -105,14 +117,14 @@ class Chapter(BaseModel):
                 is_draft=self.is_draft,
             )
 
-    def body_rendered(self):
+    def _render_body(self, custom_fences):
         return mark_safe(
             markdown(
                 self.body,
                 extensions=["pymdownx.superfences", "pymdownx.highlight", "toc"],
                 extension_configs={
                     "pymdownx.superfences": {
-                        "custom_fences": _CUSTOM_FENCES,
+                        "custom_fences": custom_fences,
                     },
                     "pymdownx.highlight": {
                         "guess_lang": False,
@@ -122,6 +134,12 @@ class Chapter(BaseModel):
                 },
             )
         )
+
+    def body_rendered(self):
+        return self._render_body(_CUSTOM_FENCES)
+
+    def body_rendered_for_feed(self):
+        return self._render_body(_CUSTOM_FENCES_FEED)
 
     def h2_headings(self):
         html = str(self.body_rendered())

--- a/templates/feeds/everything.html
+++ b/templates/feeds/everything.html
@@ -11,7 +11,7 @@
     {% include "feeds/note.html" %}
 {% elif obj.is_chapter %}
     <p><em><a href="https://simonwillison.net{{ obj.guide.get_absolute_url }}">{{ obj.guide.title }}</a> &gt;</em></p>
-    {{ obj.body_rendered }}
+    {{ obj.body_rendered_for_feed }}
     {% if obj.tags.count %}
         <p>Tags: {% for tag in obj.tags.all %}<a href="https://simonwillison.net/tags/{{ tag.tag }}">{{ tag.tag }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</p>
     {% endif %}


### PR DESCRIPTION
Chapter body in `/atom/everything/` was emitting `<markdown-copy><textarea>`,
which feed readers render as an empty text box. Swap to a `<pre>` block for
the feed-only rendering so the copy source stays visible.

https://claude.ai/code/session_01HP6J49qWpgSS91bsNg2vgx