### PR TITLE
Add Atom feeds for beats filtered by type

### DIFF
--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -1,7 +1,7 @@
 from django.contrib.syndication.views import Feed
 from django.utils.dateformat import format as date_format
 from django.utils.feedgenerator import Atom1Feed
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from blog.models import Beat, Entry, Blogmark, Quotation, Note
 from guides.models import Chapter
 
@@ -140,6 +140,27 @@ class Beats(Base):
 
     def item_link(self, item):
         return item.url
+
+
+class BeatsByType(Beats):
+    ga_source = "beats"
+
+    def get_object(self, request, beat_type):
+        valid_types = {value for value, _ in Beat.BeatType.choices}
+        if beat_type not in valid_types:
+            raise Http404
+        return beat_type
+
+    def title(self, obj):
+        label = dict(Beat.BeatType.choices)[obj]
+        return f"Simon Willison's Weblog: {label}"
+
+    def items(self, obj):
+        return (
+            Beat.objects.filter(is_draft=False, beat_type=obj)
+            .prefetch_related("tags")
+            .order_by("-created")[:15]
+        )
 
 
 class Everything(Base):

--- a/blog/search.py
+++ b/blog/search.py
@@ -485,6 +485,7 @@ def beat_type_listing(request, beat_type):
     request.GET["type"] = f"beat:{beat_type}"
     context = search(request, return_context=True)
     context["fixed_type"] = True
+    context["feed_url"] = f"/atom/beats/{beat_type}/"
     return render(request, "search.html", context)
 
 

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -901,6 +901,45 @@ class TypeListingTests(TransactionTestCase):
         self.assertContains(response, "/atom/notes/")
         self.assertContains(response, "Atom feed")
 
+    def test_beats_page_has_feed_icon(self):
+        BeatFactory()
+        response = self.client.get("/elsewhere/")
+        self.assertContains(response, "/atom/beats/")
+        self.assertContains(response, "Atom feed")
+
+    def test_beat_type_listing_page_has_feed_icon(self):
+        BeatFactory(title="Tool beat", beat_type="tool")
+        response = self.client.get("/elsewhere/tool/")
+        self.assertContains(response, "/atom/beats/tool/")
+        self.assertContains(response, "Atom feed")
+
+    def test_beat_type_listing_all_types_have_feed_icon(self):
+        for beat_type in ["release", "til", "til_update", "research", "tool", "museum"]:
+            BeatFactory(beat_type=beat_type)
+            response = self.client.get(f"/elsewhere/{beat_type}/")
+            self.assertContains(
+                response,
+                f"/atom/beats/{beat_type}/",
+                msg_prefix=f"Missing feed link for {beat_type}",
+            )
+            self.assertContains(
+                response,
+                "Atom feed",
+                msg_prefix=f"Missing Atom feed icon for {beat_type}",
+            )
+
+    def test_atom_beats_by_type_feed(self):
+        BeatFactory(title="Tool One", beat_type="tool")
+        BeatFactory(title="Release One", beat_type="release")
+        response = self.client.get("/atom/beats/tool/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Tool One")
+        self.assertNotContains(response, "Release One")
+
+    def test_atom_beats_by_type_feed_invalid_type_404s(self):
+        response = self.client.get("/atom/beats/notarealtype/")
+        self.assertEqual(response.status_code, 404)
+
 
 class MergeTagsTests(TransactionTestCase):
     def setUp(self):

--- a/config/urls.py
+++ b/config/urls.py
@@ -184,6 +184,10 @@ urlpatterns = [
     re_path(r"^atom/quotations/$", count_subscribers(feeds.Quotations().__call__)),
     re_path(r"^atom/notes/$", count_subscribers(feeds.Notes().__call__)),
     re_path(r"^atom/beats/$", count_subscribers(feeds.Beats().__call__)),
+    path(
+        "atom/beats/<slug:beat_type>/",
+        count_subscribers(feeds.BeatsByType().__call__),
+    ),
     re_path(r"^atom/everything/$", count_subscribers(feeds.Everything().__call__)),
     re_path(r"^sitemap\.xml$", feeds.sitemap),
     path("tools/", blog_views.tools),


### PR DESCRIPTION
> https://simonwillison.net/elsewhere/ has an atom feed and a subscribe icon on the page but https://simonwillison.net/elsewhere/tool/ and the other https://simonwillison.net/elsewhere/*/ pages for different beat types do not - fix that with red/green TDD

## Summary
This PR adds support for Atom feeds filtered by beat type, allowing users to subscribe to specific categories of beats (e.g., releases, tools, research, etc.) rather than all beats.

## Key Changes
- **New Feed Class**: Added `BeatsByType` feed class in `blog/feeds.py` that extends the `Beats` feed to filter by a specific beat type
  - Validates the beat type against valid choices and returns 404 for invalid types
  - Dynamically generates feed titles based on the beat type label
  - Returns the 15 most recent beats of the specified type
  
- **New URL Route**: Added `/atom/beats/<beat_type>/` endpoint in `config/urls.py` to serve type-filtered feeds

- **UI Enhancement**: Updated `beat_type_listing` view in `blog/search.py` to include the feed URL in the context, enabling the UI to display feed icons for beat type listing pages

- **Test Coverage**: Added comprehensive tests in `blog/tests.py`:
  - Feed icon visibility on beats listing page
  - Feed icon visibility on individual beat type pages
  - Feed icon presence for all valid beat types (release, til, til_update, research, tool, museum)
  - Feed content filtering by type
  - 404 handling for invalid beat types

## Implementation Details
- The `BeatsByType` feed reuses the `Beats` base class structure and inherits its formatting
- Beat type validation uses the `Beat.BeatType.choices` to ensure only valid types are accepted
- Feed URLs are now available in the template context for beat type listing pages

https://claude.ai/code/session_01H7V32JkwoR5ZWadfHY8Z3i