### PR TITLE
Refactor beat image layout from flexbox to float-based positioning

### DIFF
--- a/static/css/all.css
+++ b/static/css/all.css
@@ -1999,15 +1999,10 @@ div.beat {
 
 /* ── Beat image thumbnail ── */
 
-.beat-has-image {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.beat-has-image .beat-content {
-  flex: 1;
-  min-width: 0;
+.beat-has-image::after {
+  content: "";
+  display: block;
+  clear: both;
 }
 
 .beat-image-link,
@@ -2016,7 +2011,8 @@ div.beat {
 .beat-image-link:link:hover,
 .beat-image-link:link:focus,
 .beat-image-link:link:active {
-  flex-shrink: 0;
+  float: right;
+  margin: 0 0 8px 12px;
   border: none;
 }
 
@@ -2028,6 +2024,13 @@ div.beat {
   border: none;
   outline: none;
   display: block;
+}
+
+.beat-note blockquote code,
+.beat-note pre,
+.beat-note pre code {
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* ── Label colours by beat type ── */

--- a/templates/beat.html
+++ b/templates/beat.html
@@ -15,6 +15,9 @@
 <p class="mobile-date-eyebrow">{{ beat.created|date:"jS F Y" }}</p>
 <div class="beat{% if beat.image_url %} beat-has-image{% endif %}">
 {% include "_draft_warning.html" %}
+{% if beat.image_url %}
+  <a href="{{ beat.url }}" class="beat-image-link"><img class="beat-image" src="{{ beat.image_url }}" alt="{{ beat.image_alt }}" loading="lazy"></a>
+{% endif %}
 <div class="beat-content">
   <div class="beat-row1">
     {% if beat.beat_type == "til_update" %}
@@ -27,9 +30,6 @@
   </div>
 {% if beat.note %}<div class="beat-note blogmark-body">{{ beat.note_rendered }}</div>{% endif %}
 </div>
-{% if beat.image_url %}
-  <a href="{{ beat.url }}" class="beat-image-link"><img class="beat-image" src="{{ beat.image_url }}" alt="{{ beat.image_alt }}" loading="lazy"></a>
-{% endif %}
 </div>
 
 <div class="entryFooter">Posted <a href="/{{ beat.created|date:"Y/M/j/" }}">{{ beat.created|date:"jS F Y" }}</a> at {{ beat.created|date:"f A"|lower }}</div>

--- a/templates/includes/blog_mixed_list.html
+++ b/templates/includes/blog_mixed_list.html
@@ -68,6 +68,9 @@
 {% endif %}
 {% if item.type == "beat" %}
 <div class="beat segment{% if item.obj.image_url %} beat-has-image{% endif %}" data-type="beat" data-id="{{ item.obj.id }}">
+  {% if item.obj.image_url %}
+    <a href="{{ item.obj.url }}" class="beat-image-link"><img class="beat-image" src="{{ item.obj.image_url }}" alt="{{ item.obj.image_alt }}" loading="lazy"></a>
+  {% endif %}
   <div class="beat-content">
     <div class="beat-row1">
       {% if item.obj.beat_type == "til_update" %}
@@ -91,9 +94,6 @@
       <a href="{{ item.obj.get_absolute_url }}" rel="bookmark">{{ item.obj.created|date:"jS M Y" }}, {{ item.obj.created|date:"f A"|lower }}</a>{% if all_tags %} &middot; {% for tag in all_tags %}{{ tag.get_link }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}
     </div>
   </div>
-  {% if item.obj.image_url %}
-    <a href="{{ item.obj.url }}" class="beat-image-link"><img class="beat-image" src="{{ item.obj.image_url }}" alt="{{ item.obj.image_alt }}" loading="lazy"></a>
-  {% endif %}
 </div>
 {% endif %}
 {% endwith %}


### PR DESCRIPTION
## Summary
This PR refactors the beat image layout system from a flexbox-based approach to a float-based approach, and moves the image element to appear before the content in the DOM while maintaining visual positioning on the right.

## Key Changes

- **Layout System**: Changed `.beat-has-image` from `display: flex` with `gap` to a clearfix pattern using `::after` pseudo-element
- **Image Positioning**: Converted `.beat-image-link` from `flex-shrink: 0` to `float: right` with left margin for spacing
- **DOM Reordering**: Moved the beat image link element to appear before `.beat-content` in both `beat.html` and `blog_mixed_list.html` templates, while maintaining right-aligned visual appearance through CSS float
- **Text Wrapping**: Added `word-break: break-word` and `overflow-wrap: anywhere` to code blocks within beat notes to prevent overflow of long unbroken strings

## Implementation Details

The refactoring maintains the same visual appearance while improving semantic HTML structure. By moving the image before the content in the DOM, the image now appears first in the source order, which can benefit accessibility and progressive enhancement. The float-based layout achieves the same right-aligned positioning with the image wrapping text content naturally.

The clearfix pattern using `::after` ensures proper container height calculation when floated elements are present.

https://claude.ai/code/session_01SnaxYP3fQwCdTy9VFFrTLg