### PR TITLE
Add sighting beat type backed by iNaturalist clumps

### DIFF
--- a/blog/importers.py
+++ b/blog/importers.py
@@ -239,6 +239,125 @@ def import_tools(url):
     }
 
 
+def _sighting_photo(photo):
+    """Reduce an iNaturalist photo dict to {small_url, large_url}.
+
+    The clumps.json `thumbnail_url` is actually the medium variant; replace
+    `/medium.<ext>` with `/small.<ext>` for the grid thumbnail.
+    """
+    thumbnail_url = photo.get("thumbnail_url") or ""
+    large_url = photo.get("large_url") or thumbnail_url
+    small_url = re.sub(
+        r"/medium\.(jpe?g|png)(\?.*)?$",
+        r"/small.\1\2",
+        thumbnail_url,
+        flags=re.IGNORECASE,
+    )
+    return {"small_url": small_url or thumbnail_url, "large_url": large_url}
+
+
+def _species_name(taxon, fallback=""):
+    return (
+        (taxon or {}).get("common_name")
+        or (taxon or {}).get("scientific_name")
+        or fallback
+    )
+
+
+def import_sightings(url):
+    response = httpx.get(url)
+    response.raise_for_status()
+    data = response.json()
+    clumps = data.get("clumps") or []
+
+    created_count = 0
+    updated_count = 0
+    skipped_count = 0
+    items = []
+
+    for clump in clumps:
+        clump_id = clump.get("id")
+        if clump_id is None:
+            continue
+        observations = clump.get("observations") or []
+        if not observations:
+            continue
+
+        import_ref = "sighting:{}".format(clump_id)
+        created = parse_datetime(clump["started_at"])
+
+        # Reduce observations to the minimum the gallery template needs
+        obs_payload = []
+        for obs in observations:
+            taxon = obs.get("taxon") or {}
+            obs_payload.append(
+                {
+                    "uri": obs.get("uri") or "",
+                    "common_name": taxon.get("common_name") or "",
+                    "scientific_name": taxon.get("scientific_name") or "",
+                    "photos": [_sighting_photo(p) for p in obs.get("photos") or []],
+                }
+            )
+
+        # Species names for title and commentary
+        species_names = []
+        for sp in clump.get("species") or []:
+            name = sp.get("common_name") or sp.get("scientific_name")
+            if name and name not in species_names:
+                species_names.append(name)
+        if not species_names:
+            for obs in obs_payload:
+                name = obs["common_name"] or obs["scientific_name"]
+                if name and name not in species_names:
+                    species_names.append(name)
+
+        commentary = truncate(", ".join(species_names))
+        if species_names:
+            title = truncate(", ".join(species_names))
+        else:
+            title = "Sighting on {}".format(created.strftime("%-d %b %Y"))
+
+        first_uri = obs_payload[0]["uri"]
+
+        metadata = {
+            "started_at": clump.get("started_at"),
+            "ended_at": clump.get("ended_at"),
+            "observation_count": clump.get("observation_count")
+            or len(obs_payload),
+            "species": clump.get("species") or [],
+            "observations": obs_payload,
+        }
+
+        slug = "sighting-{}".format(clump_id)
+
+        defaults = {
+            "beat_type": "sighting",
+            "title": title,
+            "url": first_uri,
+            "slug": unique_slug(slug, created, import_ref),
+            "created": created,
+            "commentary": commentary,
+            "metadata": metadata,
+        }
+
+        beat, status = _create_or_update(import_ref, defaults)
+        if status == "created":
+            created_count += 1
+            items.append(beat)
+        elif status == "updated":
+            updated_count += 1
+            items.append(beat)
+        else:
+            skipped_count += 1
+
+    return {
+        "created": created_count,
+        "updated": updated_count,
+        "skipped": skipped_count,
+        "items": items,
+    }
+
+
 def import_museums(url):
     response = httpx.get(url)
     response.raise_for_status()

--- a/blog/management/commands/import_sightings.py
+++ b/blog/management/commands/import_sightings.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+
+from blog.importers import import_sightings
+
+
+class Command(BaseCommand):
+    help = "Import iNaturalist sighting clumps from a JSON URL as Beat objects"
+
+    def add_arguments(self, parser):
+        parser.add_argument("url", help="URL to a clumps.json file")
+
+    def handle(self, *args, **options):
+        result = import_sightings(options["url"])
+        self.stdout.write(
+            "Created {}, updated {}, skipped {}".format(
+                result["created"], result["updated"], result["skipped"]
+            )
+        )

--- a/blog/migrations/0048_add_sighting_beat_type.py
+++ b/blog/migrations/0048_add_sighting_beat_type.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("blog", "0047_beat_note"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="beat",
+            name="beat_type",
+            field=models.CharField(
+                choices=[
+                    ("release", "Release"),
+                    ("til", "TIL"),
+                    ("til_update", "TIL updated"),
+                    ("research", "Research"),
+                    ("tool", "Tool"),
+                    ("museum", "Museum"),
+                    ("sighting", "Sighting"),
+                ],
+                db_index=True,
+                max_length=20,
+            ),
+        ),
+    ]

--- a/blog/models.py
+++ b/blog/models.py
@@ -549,6 +549,7 @@ class Beat(BaseModel):
         RESEARCH = "research", "Research"
         TOOL = "tool", "Tool"
         MUSEUM = "museum", "Museum"
+        SIGHTING = "sighting", "Sighting"
 
     beat_type = models.CharField(max_length=20, choices=BeatType.choices, db_index=True)
 
@@ -574,6 +575,34 @@ class Beat(BaseModel):
         if self.note:
             return mark_safe(markdown(self.note))
         return ""
+
+    def sighting_time_range(self):
+        """Format the sighting time range from metadata started_at/ended_at.
+
+        Returns "10:23 AM" for a single moment, "9:15 AM – 5:42 PM" for a
+        same-day range, or "9:15 AM – 15 Mar 5:42 PM" for a cross-day range.
+        Falls back to the created timestamp when metadata is missing.
+        """
+        from dateutil.parser import parse as parse_datetime
+
+        md = self.metadata or {}
+        start = md.get("started_at")
+        end = md.get("ended_at")
+        if not start:
+            return self.created.strftime("%-I:%M %p")
+        s = parse_datetime(start)
+        if not end or end == start:
+            return s.strftime("%-I:%M %p")
+        e = parse_datetime(end)
+        if s.date() == e.date():
+            return "{} – {}".format(
+                s.strftime("%-I:%M %p"), e.strftime("%-I:%M %p")
+            )
+        return "{} – {} {}".format(
+            s.strftime("%-I:%M %p"),
+            e.strftime("%-d %b"),
+            e.strftime("%-I:%M %p"),
+        )
 
     def index_components(self):
         return {

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -2245,6 +2245,262 @@ class ImporterViewTests(TransactionTestCase):
         self.assertContains(response, "/admin/importers/")
         self.assertContains(response, "Beat Importers")
 
+    def test_importers_page_lists_sightings(self):
+        self.client.login(username="admin", password="password")
+        response = self.client.get("/admin/importers/")
+        assert response.status_code == 200
+        self.assertContains(response, "Sightings")
+        self.assertContains(response, "clumps.json")
+
+    def _sighting_clumps_fixture(self):
+        return {
+            "total_observations": 4,
+            "total_clumps": 2,
+            "clumps": [
+                {
+                    "id": 1,
+                    "started_at": "2015-06-03T10:23:01-07:00",
+                    "ended_at": "2015-06-03T10:23:01-07:00",
+                    "observation_count": 1,
+                    "species": [
+                        {
+                            "common_name": "Side-striped palm pit viper",
+                            "scientific_name": "Bothriechis lateralis",
+                            "count": 1,
+                        }
+                    ],
+                    "observations": [
+                        {
+                            "id": 9687475,
+                            "uri": "https://www.inaturalist.org/observations/9687475",
+                            "taxon": {
+                                "common_name": "Side-striped palm pit viper",
+                                "scientific_name": "Bothriechis lateralis",
+                            },
+                            "photos": [
+                                {
+                                    "thumbnail_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/13245173/medium.jpg",
+                                    "large_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/13245173/large.jpg",
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "id": 2,
+                    "started_at": "2024-03-14T09:15:00-07:00",
+                    "ended_at": "2024-03-15T17:42:00-07:00",
+                    "observation_count": 3,
+                    "species": [
+                        {
+                            "common_name": "Common newt",
+                            "scientific_name": "Lissotriton vulgaris",
+                            "count": 2,
+                        },
+                        {
+                            "common_name": "Mallard",
+                            "scientific_name": "Anas platyrhynchos",
+                            "count": 1,
+                        },
+                    ],
+                    "observations": [
+                        {
+                            "id": 100,
+                            "uri": "https://www.inaturalist.org/observations/100",
+                            "taxon": {
+                                "common_name": "Common newt",
+                                "scientific_name": "Lissotriton vulgaris",
+                            },
+                            "photos": [
+                                {
+                                    "thumbnail_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/100/medium.jpg",
+                                    "large_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/100/large.jpg",
+                                }
+                            ],
+                        },
+                        {
+                            "id": 101,
+                            "uri": "https://www.inaturalist.org/observations/101",
+                            "taxon": {
+                                "common_name": "Mallard",
+                                "scientific_name": "Anas platyrhynchos",
+                            },
+                            "photos": [
+                                {
+                                    "thumbnail_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/101/medium.jpg",
+                                    "large_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/101/large.jpg",
+                                }
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+
+    def test_api_run_importer_sightings(self):
+        from unittest.mock import patch, MagicMock
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = self._sighting_clumps_fixture()
+        mock_response.raise_for_status = MagicMock()
+
+        self.client.login(username="admin", password="password")
+        with patch("blog.importers.httpx.get", return_value=mock_response):
+            response = self.client.post(
+                "/api/run-importer/",
+                json.dumps({"importer": "sightings"}),
+                content_type="application/json",
+            )
+        assert response.status_code == 200, response.content
+        data = json.loads(response.content)
+        assert data["created"] == 2
+        assert data["total"] == 2
+        assert 'class="beat-label sighting"' in data["items_html"]
+        assert "Side-striped palm pit viper" in data["items_html"]
+
+        from blog.models import Beat
+
+        beat = Beat.objects.get(import_ref="sighting:1")
+        assert beat.beat_type == "sighting"
+        assert beat.url == "https://www.inaturalist.org/observations/9687475"
+        # commentary is just species names, no observation count prefix
+        assert beat.commentary == "Side-striped palm pit viper"
+        # Metadata stores the data needed for gallery rendering
+        md = beat.metadata
+        assert md["started_at"] == "2015-06-03T10:23:01-07:00"
+        assert md["ended_at"] == "2015-06-03T10:23:01-07:00"
+        assert md["observation_count"] == 1
+        assert len(md["observations"]) == 1
+        photo = md["observations"][0]["photos"][0]
+        # small_url derived from thumbnail_url by replacing /medium.jpg -> /small.jpg
+        assert photo["small_url"].endswith("/small.jpg")
+        assert photo["large_url"].endswith("/large.jpg")
+
+        beat2 = Beat.objects.get(import_ref="sighting:2")
+        # Multi-species commentary, no observation count
+        assert "Common newt" in beat2.commentary
+        assert "Mallard" in beat2.commentary
+        assert "observation" not in beat2.commentary.lower()
+
+    def test_api_run_importer_sightings_skips_unchanged(self):
+        from unittest.mock import patch, MagicMock
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = self._sighting_clumps_fixture()
+        mock_response.raise_for_status = MagicMock()
+
+        self.client.login(username="admin", password="password")
+        with patch("blog.importers.httpx.get", return_value=mock_response):
+            self.client.post(
+                "/api/run-importer/",
+                json.dumps({"importer": "sightings"}),
+                content_type="application/json",
+            )
+        with patch("blog.importers.httpx.get", return_value=mock_response):
+            response = self.client.post(
+                "/api/run-importer/",
+                json.dumps({"importer": "sightings"}),
+                content_type="application/json",
+            )
+        data = json.loads(response.content)
+        assert data["created"] == 0
+        assert data["updated"] == 0
+        assert data["skipped"] == 2
+
+    def test_sighting_renders_captioned_image_gallery_in_mixed_list(self):
+        from django.template.loader import render_to_string
+        from blog.factories import BeatFactory
+
+        beat = BeatFactory(
+            beat_type="sighting",
+            title="Side-striped palm pit viper",
+            url="https://www.inaturalist.org/observations/9687475",
+            commentary="Side-striped palm pit viper",
+            metadata={
+                "started_at": "2015-06-03T10:23:01-07:00",
+                "ended_at": "2015-06-03T10:23:01-07:00",
+                "observation_count": 1,
+                "species": [],
+                "observations": [
+                    {
+                        "uri": "https://www.inaturalist.org/observations/9687475",
+                        "common_name": "Side-striped palm pit viper",
+                        "scientific_name": "Bothriechis lateralis",
+                        "photos": [
+                            {
+                                "small_url": "https://example.com/photos/13245173/small.jpg",
+                                "large_url": "https://example.com/photos/13245173/large.jpg",
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        html = render_to_string(
+            "includes/blog_mixed_list.html",
+            {"items": [{"type": "beat", "obj": beat}]},
+        )
+        assert "<captioned-image-gallery" in html
+        assert "https://example.com/photos/13245173/small.jpg" in html
+        assert "https://example.com/photos/13245173/large.jpg" in html
+        # figcaption with link to the observation
+        assert "https://www.inaturalist.org/observations/9687475" in html
+        assert 'class="beat-label sighting"' in html
+
+    def test_sighting_time_range_same_time(self):
+        from blog.factories import BeatFactory
+
+        beat = BeatFactory(
+            beat_type="sighting",
+            metadata={
+                "started_at": "2015-06-03T10:23:01-07:00",
+                "ended_at": "2015-06-03T10:23:01-07:00",
+            },
+        )
+        # No dash for a single moment
+        result = beat.sighting_time_range()
+        assert "10:23" in result
+        assert "–" not in result and " - " not in result
+
+    def test_sighting_time_range_same_day(self):
+        from blog.factories import BeatFactory
+
+        beat = BeatFactory(
+            beat_type="sighting",
+            metadata={
+                "started_at": "2024-03-14T09:15:00-07:00",
+                "ended_at": "2024-03-14T17:42:00-07:00",
+            },
+        )
+        result = beat.sighting_time_range()
+        assert "9:15" in result
+        assert "5:42" in result
+        # En-dash separator
+        assert "–" in result
+
+    def test_sighting_time_range_cross_day(self):
+        from blog.factories import BeatFactory
+
+        beat = BeatFactory(
+            beat_type="sighting",
+            metadata={
+                "started_at": "2024-03-14T09:15:00-07:00",
+                "ended_at": "2024-03-15T17:42:00-07:00",
+            },
+        )
+        result = beat.sighting_time_range()
+        assert "9:15" in result
+        # Date for the end portion (Mar)
+        assert "Mar" in result
+        assert "5:42" in result
+
+    def test_base_html_loads_captioned_image_gallery(self):
+        path = "templates/base.html"
+        with open(path) as f:
+            contents = f.read()
+        assert "captioned-image-gallery" in contents
+        assert "/static/captioned-image-gallery.js" in contents
+
 
 class SponsorMessageTests(TransactionTestCase):
     def test_no_sponsor_message_no_banner(self):

--- a/blog/views.py
+++ b/blog/views.py
@@ -1251,6 +1251,11 @@ IMPORTERS = {
         "description": "Import museums from niche-museums.com",
         "url": "https://www.niche-museums.com/museums.json",
     },
+    "sightings": {
+        "name": "Sightings",
+        "description": "Import iNaturalist sighting clumps",
+        "url": "https://raw.githubusercontent.com/simonw/inaturalist-clumps/refs/heads/main/clumps.json",
+    },
 }
 
 
@@ -1269,6 +1274,7 @@ def api_run_importer(request):
         import_museums,
         import_releases,
         import_research,
+        import_sightings,
         import_tils,
         import_tools,
     )
@@ -1288,6 +1294,7 @@ def api_run_importer(request):
         "tils": import_tils,
         "tools": import_tools,
         "museums": import_museums,
+        "sightings": import_sightings,
     }
 
     try:

--- a/static/captioned-image-gallery.js
+++ b/static/captioned-image-gallery.js
@@ -1,0 +1,520 @@
+/**
+ * <captioned-image-gallery> web component
+ *
+ * Lays out a list of <figure> children in justified rows: items in a row
+ * share a common height, with widths proportional to each image's aspect
+ * ratio. Handles mixed portrait / landscape mixes naturally.
+ *
+ * Clicking any image opens a full-screen lightbox with prev / next
+ * navigation (arrow keys, swipe on touch devices, on-screen arrows). All
+ * <captioned-image-gallery> elements on the page form a single navigation
+ * cycle and the figure list is recomputed on every step, so galleries
+ * added or removed after load are picked up automatically.
+ *
+ * Markup:
+ *   <captioned-image-gallery>
+ *     <figure>
+ *       <a href="full.jpg"><img src="thumb.jpg" alt="..."></a>
+ *       <figcaption>caption text</figcaption>
+ *     </figure>
+ *     ...
+ *   </captioned-image-gallery>
+ *
+ * Attributes:
+ *   show-counter   Display "n / total" position counter in the lightbox
+ *                  while viewing a figure from this gallery.
+ */
+
+const STYLES = `
+captioned-image-gallery:defined {
+  --gap: 6px;
+  --max-row-height: 240px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--gap);
+  background: #f4f4f4;
+  padding: var(--gap);
+  border-radius: 4px;
+}
+
+captioned-image-gallery:defined > figure {
+  margin: 0;
+  position: relative;
+  overflow: hidden;
+  background: #ddd;
+  border-radius: 2px;
+  min-width: 0;
+}
+
+captioned-image-gallery:defined > figure > a {
+  display: block;
+  width: 100%;
+  height: 100%;
+  text-decoration: none;
+  cursor: zoom-in;
+}
+
+captioned-image-gallery:defined img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+captioned-image-gallery:defined figcaption {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  right: 4px;
+  margin: 0;
+  padding: 2px 6px;
+  font-size: 11px;
+  color: white;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 2px;
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+captioned-image-gallery:defined figcaption a {
+  pointer-events: auto;
+  color: inherit;
+  text-decoration: underline;
+}
+
+captioned-image-gallery:defined figcaption a:hover {
+  color: #cfe8ff;
+}
+
+dialog.captioned-gallery-modal {
+  border: none;
+  padding: 0;
+  margin: 0;
+  width: 100vw;
+  height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
+  background: #000;
+  color: #fff;
+  overflow: hidden;
+}
+
+dialog.captioned-gallery-modal::backdrop {
+  background: rgba(0, 0, 0, 0.95);
+}
+
+.captioned-gallery-modal-stage {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  touch-action: pan-y;
+}
+
+.captioned-gallery-modal-img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+  user-select: none;
+  -webkit-user-drag: none;
+  pointer-events: none;
+}
+
+.captioned-gallery-modal-btn {
+  position: absolute;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: color 0.15s ease, background 0.15s ease;
+  z-index: 2;
+  font-family: inherit;
+}
+
+.captioned-gallery-modal-btn:hover,
+.captioned-gallery-modal-btn:focus-visible {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
+  outline: none;
+}
+
+.captioned-gallery-modal-btn svg {
+  width: 24px;
+  height: 24px;
+  display: block;
+}
+
+.captioned-gallery-modal-close {
+  top: 12px;
+  right: 12px;
+  width: 44px;
+  height: 44px;
+}
+
+.captioned-gallery-modal-prev,
+.captioned-gallery-modal-next {
+  top: 50%;
+  transform: translateY(-50%);
+  width: 56px;
+  height: 56px;
+}
+
+.captioned-gallery-modal-prev {
+  left: 8px;
+}
+
+.captioned-gallery-modal-next {
+  right: 8px;
+}
+
+.captioned-gallery-modal-caption-wrap {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.65);
+  padding: 12px 72px;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.captioned-gallery-modal-caption a {
+  pointer-events: auto;
+  color: #9cf;
+  text-decoration: underline;
+}
+
+.captioned-gallery-modal-caption a:hover {
+  color: #cfe8ff;
+}
+
+.captioned-gallery-modal-counter {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.55);
+  margin-bottom: 2px;
+}
+
+.captioned-gallery-modal-counter[hidden] {
+  display: none;
+}
+
+.captioned-gallery-modal-caption {
+  font-size: 14px;
+  line-height: 1.4;
+  color: #fff;
+  word-wrap: break-word;
+}
+
+@media (max-width: 600px) {
+  .captioned-gallery-modal-prev,
+  .captioned-gallery-modal-next {
+    width: 44px;
+    height: 44px;
+  }
+
+  .captioned-gallery-modal-caption-wrap {
+    padding: 10px 16px 14px;
+  }
+}
+`;
+
+function injectStyles() {
+  if (document.getElementById('captioned-image-gallery-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'captioned-image-gallery-styles';
+  style.textContent = STYLES;
+  document.head.appendChild(style);
+}
+
+class CaptionedImageGallery extends HTMLElement {
+  static instances = new Set();
+  static modal = null;
+  static currentFigure = null;
+
+  connectedCallback() {
+    this.figures = [...this.querySelectorAll(':scope > figure')];
+    if (!this.figures.length) return;
+    this.dataset.count = this.figures.length;
+
+    CaptionedImageGallery.instances.add(this);
+
+    // Wire up clicks on each figure's anchor: open the lightbox instead
+    this.figures.forEach(figure => {
+      const a = figure.querySelector('a');
+      if (a && !a.dataset.captionedGalleryWired) {
+        a.dataset.captionedGalleryWired = '1';
+        a.addEventListener('click', e => {
+          e.preventDefault();
+          CaptionedImageGallery.openFor(figure);
+        });
+      }
+    });
+
+    // Layout once images have natural dimensions available, then keep
+    // it in sync with container width changes
+    const imgs = this.figures.map(f => f.querySelector('img')).filter(Boolean);
+    Promise.all(imgs.map(img => {
+      if (img.complete && img.naturalWidth > 0) return Promise.resolve();
+      return new Promise(res => {
+        img.addEventListener('load', res, { once: true });
+        img.addEventListener('error', res, { once: true });
+      });
+    })).then(() => {
+      this.applyLayout();
+      this._lastWidth = this.clientWidth;
+      this._ro = new ResizeObserver(entries => {
+        const w = entries[0].contentRect.width;
+        if (Math.abs(w - this._lastWidth) > 0.5) {
+          this._lastWidth = w;
+          this.applyLayout();
+        }
+      });
+      this._ro.observe(this);
+    });
+  }
+
+  disconnectedCallback() {
+    this._ro?.disconnect();
+    CaptionedImageGallery.instances.delete(this);
+  }
+
+  ratioOf(figure) {
+    const img = figure.querySelector('img');
+    if (!img) return 1;
+    const r = img.naturalWidth / img.naturalHeight;
+    return isFinite(r) && r > 0 ? r : 1;
+  }
+
+  applyLayout() {
+    const ratios = this.figures.map(f => this.ratioOf(f));
+    const count = this.figures.length;
+
+    this.figures.forEach(f => {
+      f.style.width = '';
+      f.style.height = '';
+      f.style.aspectRatio = '';
+      f.style.maxHeight = '';
+    });
+
+    const cs = getComputedStyle(this);
+    const padL = parseFloat(cs.paddingLeft) || 0;
+    const padR = parseFloat(cs.paddingRight) || 0;
+    const gap = parseFloat(cs.gap) || 0;
+    const containerW = this.clientWidth - padL - padR;
+    const maxH = parseFloat(cs.getPropertyValue('--max-row-height')) || 240;
+
+    if (containerW <= 0) return;
+
+    if (count === 1) {
+      const f = this.figures[0];
+      const r = ratios[0];
+      this.dataset.orientation = r >= 1 ? 'landscape' : 'portrait';
+      let h = maxH;
+      let w = h * r;
+      if (w > containerW) {
+        w = containerW;
+        h = w / r;
+      }
+      f.style.width = w + 'px';
+      f.style.height = h + 'px';
+      return;
+    }
+
+    const splits = this.getRowSplits(count);
+    let idx = 0;
+    splits.forEach(rowCount => {
+      const rowFigs = this.figures.slice(idx, idx + rowCount);
+      const rowRatios = ratios.slice(idx, idx + rowCount);
+      const sum = rowRatios.reduce((a, b) => a + b, 0);
+      const rowAvailW = Math.max(0, containerW - (rowCount - 1) * gap);
+      const naturalH = sum > 0 ? rowAvailW / sum : maxH;
+      const rowH = Math.min(naturalH, maxH);
+      rowFigs.forEach((f, i) => {
+        f.style.width = (rowH * rowRatios[i]) + 'px';
+        f.style.height = rowH + 'px';
+      });
+      idx += rowCount;
+    });
+  }
+
+  getRowSplits(n) {
+    if (n <= 3) return [n];
+    // Cap rows at 3 wide. Use rows of 3 plus rows of 2 to make up the
+    // remainder; smaller rows lead so the bottom row is the widest.
+    const splits = [];
+    const rem = n % 3;
+    let twos, threes;
+    if (rem === 0) {
+      twos = 0;
+      threes = n / 3;
+    } else if (rem === 1) {
+      twos = 2;
+      threes = (n - 4) / 3;
+    } else {
+      twos = 1;
+      threes = (n - 2) / 3;
+    }
+    for (let i = 0; i < twos; i++) splits.push(2);
+    for (let i = 0; i < threes; i++) splits.push(3);
+    return splits;
+  }
+
+  // ----- Cross-gallery flat list (in document order) -----
+
+  static getAllFigures() {
+    const sorted = [...CaptionedImageGallery.instances].sort((a, b) => {
+      if (a === b) return 0;
+      const pos = a.compareDocumentPosition(b);
+      if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+      if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+      return 0;
+    });
+    const all = [];
+    sorted.forEach(g => {
+      [...g.querySelectorAll(':scope > figure')].forEach(f => all.push(f));
+    });
+    return all;
+  }
+
+  static openFor(figure) {
+    if (!figure) return;
+    if (!CaptionedImageGallery.modal) CaptionedImageGallery.buildModal();
+    CaptionedImageGallery.currentFigure = figure;
+    CaptionedImageGallery.renderModal();
+    if (!CaptionedImageGallery.modal.open) CaptionedImageGallery.modal.showModal();
+  }
+
+  static step(direction) {
+    // Recompute the list every step so newly-added galleries are picked up
+    const all = CaptionedImageGallery.getAllFigures();
+    if (!all.length) return;
+    const n = all.length;
+    let idx = all.indexOf(CaptionedImageGallery.currentFigure);
+    if (idx < 0) idx = 0; // current figure was removed; restart at 0
+    else idx = (idx + direction + n) % n;
+    CaptionedImageGallery.openFor(all[idx]);
+  }
+
+  static next() { CaptionedImageGallery.step(1); }
+  static prev() { CaptionedImageGallery.step(-1); }
+
+  static renderModal() {
+    const figure = CaptionedImageGallery.currentFigure;
+    if (!figure) return;
+    const a = figure.querySelector('a');
+    const thumb = figure.querySelector('img');
+    const caption = figure.querySelector('figcaption');
+    const fullSrc = a ? a.href : (thumb ? thumb.src : '');
+
+    const img = CaptionedImageGallery.modal.querySelector('.captioned-gallery-modal-img');
+    img.src = fullSrc;
+    img.alt = thumb ? thumb.alt : '';
+
+    const cap = CaptionedImageGallery.modal.querySelector('.captioned-gallery-modal-caption');
+    cap.replaceChildren();
+    if (caption) {
+      for (const node of caption.childNodes) {
+        cap.appendChild(node.cloneNode(true));
+      }
+    }
+
+    // Counter is opt-in via show-counter on the figure's parent gallery
+    const parent = figure.closest('captioned-image-gallery');
+    const showCounter = parent && parent.hasAttribute('show-counter');
+    const counter = CaptionedImageGallery.modal.querySelector('.captioned-gallery-modal-counter');
+    counter.hidden = !showCounter;
+    if (showCounter) {
+      const all = CaptionedImageGallery.getAllFigures();
+      const idx = all.indexOf(figure);
+      counter.textContent = `${idx + 1} / ${all.length}`;
+    } else {
+      counter.textContent = '';
+    }
+  }
+
+  static buildModal() {
+    const dialog = document.createElement('dialog');
+    dialog.className = 'captioned-gallery-modal';
+    dialog.innerHTML = `
+      <div class="captioned-gallery-modal-stage">
+        <img class="captioned-gallery-modal-img" alt="">
+      </div>
+      <button type="button" class="captioned-gallery-modal-btn captioned-gallery-modal-prev" aria-label="Previous image">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 6 9 12 15 18"/></svg>
+      </button>
+      <button type="button" class="captioned-gallery-modal-btn captioned-gallery-modal-next" aria-label="Next image">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 6 15 12 9 18"/></svg>
+      </button>
+      <button type="button" class="captioned-gallery-modal-btn captioned-gallery-modal-close" aria-label="Close">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>
+      </button>
+      <div class="captioned-gallery-modal-caption-wrap">
+        <span class="captioned-gallery-modal-counter" hidden></span>
+        <div class="captioned-gallery-modal-caption"></div>
+      </div>
+    `;
+
+    dialog.querySelector('.captioned-gallery-modal-close').addEventListener('click', () => dialog.close());
+    dialog.querySelector('.captioned-gallery-modal-prev').addEventListener('click', () => CaptionedImageGallery.prev());
+    dialog.querySelector('.captioned-gallery-modal-next').addEventListener('click', () => CaptionedImageGallery.next());
+
+    // Tap on stage background (not the image, not buttons) closes the modal
+    const stage = dialog.querySelector('.captioned-gallery-modal-stage');
+    stage.addEventListener('click', e => {
+      if (e.target === stage) dialog.close();
+    });
+
+    // Keyboard navigation while open
+    dialog.addEventListener('keydown', e => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); CaptionedImageGallery.prev(); }
+      else if (e.key === 'ArrowRight') { e.preventDefault(); CaptionedImageGallery.next(); }
+    });
+
+    // Single-finger horizontal swipe
+    let sx = null, sy = null, st = 0;
+    dialog.addEventListener('touchstart', e => {
+      if (e.touches.length === 1) {
+        sx = e.touches[0].clientX;
+        sy = e.touches[0].clientY;
+        st = Date.now();
+      } else {
+        sx = null;
+      }
+    }, { passive: true });
+
+    dialog.addEventListener('touchend', e => {
+      if (sx === null || e.changedTouches.length !== 1) { sx = null; return; }
+      const dx = e.changedTouches[0].clientX - sx;
+      const dy = e.changedTouches[0].clientY - sy;
+      const dt = Date.now() - st;
+      sx = null;
+      if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy) * 1.5 && dt < 600) {
+        if (dx < 0) CaptionedImageGallery.next();
+        else CaptionedImageGallery.prev();
+      }
+    }, { passive: true });
+
+    document.body.appendChild(dialog);
+    CaptionedImageGallery.modal = dialog;
+  }
+}
+
+injectStyles();
+
+if (!customElements.get('captioned-image-gallery')) {
+  customElements.define('captioned-image-gallery', CaptionedImageGallery);
+}

--- a/static/css/all.css
+++ b/static/css/all.css
@@ -2083,6 +2083,11 @@ div.beat {
   color: #00695c;
   border: 1px solid #80cbc4;
 }
+.beat-label.sighting {
+  background: #e8f5e9;
+  color: #1b5e20;
+  border: 1px solid #81c784;
+}
 
 /* ── Beat type navigation links ── */
 
@@ -2111,6 +2116,7 @@ a.beat-type-link:hover {
 [data-theme="dark"] .beat-label.research        { background: #2a2000; color: #c8a830; border-color: #5a4800; }
 [data-theme="dark"] .beat-label.tool            { background: #2a0a1e; color: #e060b0; border-color: #6a1a4e; }
 [data-theme="dark"] .beat-label.museum          { background: #0a2622; color: #4db6ac; border-color: #1a5c52; }
+[data-theme="dark"] .beat-label.sighting        { background: #102a14; color: #7cd393; border-color: #2d5b3a; }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme]) .beat-label.release    { background: var(--color-purple-light); color: var(--color-purple-accent); border-color: var(--color-purple-border); }
@@ -2120,4 +2126,5 @@ a.beat-type-link:hover {
   :root:not([data-theme]) .beat-label.research        { background: #2a2000; color: #c8a830; border-color: #5a4800; }
   :root:not([data-theme]) .beat-label.tool            { background: #2a0a1e; color: #e060b0; border-color: #6a1a4e; }
   :root:not([data-theme]) .beat-label.museum          { background: #0a2622; color: #4db6ac; border-color: #1a5c52; }
+  :root:not([data-theme]) .beat-label.sighting        { background: #102a14; color: #7cd393; border-color: #2d5b3a; }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,7 +45,7 @@
     </ul>
 </div>
 {% endblock %}
-<style>image-gallery:not(:defined) img {max-height: 150px;}</style>
+<style>image-gallery:not(:defined) img {max-height: 150px;} captioned-image-gallery:not(:defined) > figure {max-height: 240px; overflow: hidden;}</style>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('h2[id],h3[id],h4[id],h5[id],h6[id]').forEach(el => {
@@ -69,7 +69,8 @@ document.addEventListener('DOMContentLoaded', () => {
 <script type="module">
 const config = [
   {"tag": "lite-youtube", "js": "/static/lite-yt-embed.js", "css": "/static/lite-yt-embed.css"},
-  {"tag": "image-gallery", "js": "/static/image-gallery.js", "css": null}
+  {"tag": "image-gallery", "js": "/static/image-gallery.js", "css": null},
+  {"tag": "captioned-image-gallery", "js": "/static/captioned-image-gallery.js", "css": null}
 ];
 for (const {tag, js, css} of config) {
   if (document.querySelector(tag)) {

--- a/templates/beat.html
+++ b/templates/beat.html
@@ -13,8 +13,21 @@
 {% load entry_tags %}
 {% block item_content %}
 <p class="mobile-date-eyebrow">{{ beat.created|date:"jS F Y" }}</p>
-<div class="beat{% if beat.image_url %} beat-has-image{% endif %}">
+<div class="beat{% if beat.image_url %} beat-has-image{% endif %}{% if beat.beat_type == "sighting" %} beat-sighting{% endif %}">
 {% include "_draft_warning.html" %}
+{% if beat.beat_type == "sighting" %}
+<div class="beat-content">
+  <div class="beat-row1">
+    <span class="beat-label sighting">Sighting</span>
+    <span class="beat-title"><a href="{{ beat.url }}">{{ beat.sighting_time_range }}</a></span>
+    {% if beat.commentary %}<span class="beat-commit">&mdash; {{ beat.commentary }}</span>{% endif %}
+  </div>
+  <captioned-image-gallery>
+    {% for obs in beat.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
+  </captioned-image-gallery>
+{% if beat.note %}<div class="beat-note blogmark-body">{{ beat.note_rendered }}</div>{% endif %}
+</div>
+{% else %}
 {% if beat.image_url %}
   <a href="{{ beat.url }}" class="beat-image-link"><img class="beat-image" src="{{ beat.image_url }}" alt="{{ beat.image_alt }}" loading="lazy"></a>
 {% endif %}
@@ -30,6 +43,7 @@
   </div>
 {% if beat.note %}<div class="beat-note blogmark-body">{{ beat.note_rendered }}</div>{% endif %}
 </div>
+{% endif %}
 </div>
 
 <div class="entryFooter">Posted <a href="/{{ beat.created|date:"Y/M/j/" }}">{{ beat.created|date:"jS F Y" }}</a> at {{ beat.created|date:"f A"|lower }}</div>

--- a/templates/includes/blog_mixed_list.html
+++ b/templates/includes/blog_mixed_list.html
@@ -67,6 +67,23 @@
 </div>
 {% endif %}
 {% if item.type == "beat" %}
+{% if item.obj.beat_type == "sighting" %}
+<div class="beat segment beat-sighting" data-type="beat" data-id="{{ item.obj.id }}">
+  <div class="beat-content">
+    <div class="beat-row1">
+      <span class="beat-label sighting">Sighting</span>
+      <span class="beat-title"><a href="{{ item.obj.url }}">{{ item.obj.sighting_time_range }}</a></span>
+      {% if item.obj.commentary %}<span class="beat-commit">&mdash; {{ item.obj.commentary }}</span>{% endif %}
+    </div>
+    <captioned-image-gallery>
+      {% for obs in item.obj.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
+    </captioned-image-gallery>
+    <div class="beat-meta beat-row2">
+      <a href="{{ item.obj.get_absolute_url }}" rel="bookmark">{{ item.obj.created|date:"jS M Y" }}</a>{% if all_tags %} &middot; {% for tag in all_tags %}{{ tag.get_link }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}
+    </div>
+  </div>
+</div>
+{% else %}
 <div class="beat segment{% if item.obj.image_url %} beat-has-image{% endif %}" data-type="beat" data-id="{{ item.obj.id }}">
   {% if item.obj.image_url %}
     <a href="{{ item.obj.url }}" class="beat-image-link"><img class="beat-image" src="{{ item.obj.image_url }}" alt="{{ item.obj.image_alt }}" loading="lazy"></a>
@@ -95,6 +112,7 @@
     </div>
   </div>
 </div>
+{% endif %}
 {% endif %}
 {% endwith %}
 {% endfor %}

--- a/templates/includes/importer_results.html
+++ b/templates/includes/importer_results.html
@@ -13,6 +13,8 @@
       <span class="beat-label tool">Tool</span>
     {% elif item.beat_type == "museum" %}
       <span class="beat-label museum">Museum</span>
+    {% elif item.beat_type == "sighting" %}
+      <span class="beat-label sighting">Sighting</span>
     {% endif %}
     <span class="beat-title"><a href="{{ item.url }}">{{ item.title }}</a></span>
     {% if item.commentary %}<span class="beat-commit">&mdash; {{ item.commentary }}</span>{% endif %}


### PR DESCRIPTION
> Clone simonw/tools to /tmp and look at inat-sightings.html
> 
> We are going to add a new type of beat called “sightings” based on that prototype
> 
> A sighting is a group of observations (a “clump” according to the API that uses) in a single beat, rendered using that image gallery component
> 
> The blog already has a mechanism for only loading the code for a web component if it is present on the page - we will use that
> 
> These sighting beats are shown with the date and time or time range similar to the inat-sightings.html prototype
> 
> We need an importer mechanism wired up on /admin/importers too
> 
> Run tests first. Build with red/green TDD and a mocked API response

Each sighting beat is a "clump" of iNaturalist observations rendered with
a new <captioned-image-gallery> component (a renamed copy of the prototype
in simonw/tools so the existing <image-gallery> stays untouched). The
component lazy-loads via the existing base.html querySelector mechanism.
Time ranges (single time, same-day, cross-day) are formatted from the
clump's started_at/ended_at metadata. Imports run from /admin/importers.

https://claude.ai/code/session_018CLLDeHNykeKaCbDauGALE