### PR TITLE
Pluralize sighting page titles, embed photos and link to local page in feeds

### DIFF
--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -133,12 +133,20 @@ class Beats(Base):
         return item.title
 
     def item_description(self, item):
+        if item.beat_type == "sighting":
+            return item.sighting_feed_html()
         desc = f'<p><a href="{item.url}">{item.title}</a></p>'
         if item.commentary:
             desc += f"<p>{item.commentary}</p>"
         return desc
 
     def item_link(self, item):
+        if item.beat_type == "sighting":
+            return (
+                "https://simonwillison.net"
+                + item.get_absolute_url()
+                + "#atom-%s" % self.ga_source
+            )
         return item.url
 
 
@@ -152,7 +160,7 @@ class BeatsByType(Beats):
         return beat_type
 
     def title(self, obj):
-        label = dict(Beat.BeatType.choices)[obj]
+        label = Beat.BEAT_TYPE_PLURALS.get(obj) or dict(Beat.BeatType.choices)[obj]
         return f"Simon Willison's Weblog: {label}"
 
     def items(self, obj):

--- a/blog/models.py
+++ b/blog/models.py
@@ -551,6 +551,16 @@ class Beat(BaseModel):
         MUSEUM = "museum", "Museum"
         SIGHTING = "sighting", "Sighting"
 
+    BEAT_TYPE_PLURALS = {
+        "release": "Releases",
+        "til": "TILs",
+        "til_update": "TIL updates",
+        "research": "Research",
+        "tool": "Tools",
+        "museum": "Museums",
+        "sighting": "Sightings",
+    }
+
     beat_type = models.CharField(max_length=20, choices=BeatType.choices, db_index=True)
 
     # The linked title — what appears as the clickable text in the timeline
@@ -575,6 +585,30 @@ class Beat(BaseModel):
         if self.note:
             return mark_safe(markdown(self.note))
         return ""
+
+    def sighting_feed_html(self):
+        """HTML used for sighting beats in atom feeds: embedded photos,
+        followed by commentary and an optional note. Falls back to a
+        title-link if metadata is missing."""
+        parts = []
+        for obs in (self.metadata or {}).get("observations") or []:
+            name = obs.get("common_name") or obs.get("scientific_name") or ""
+            for photo in obs.get("photos") or []:
+                large = photo.get("large_url") or photo.get("small_url") or ""
+                if not large:
+                    continue
+                parts.append(
+                    '<p><img src="{}" alt="{}"></p>'.format(escape(large), escape(name))
+                )
+        if self.commentary:
+            parts.append("<p>{}</p>".format(escape(self.commentary)))
+        if self.note:
+            parts.append(self.note_rendered())
+        if not parts:
+            parts.append(
+                '<p><a href="{}">{}</a></p>'.format(escape(self.url), escape(self.title))
+            )
+        return mark_safe("".join(parts))
 
     def sighting_time_range(self):
         """Format the sighting time range from metadata started_at/ended_at.

--- a/blog/search.py
+++ b/blog/search.py
@@ -342,14 +342,7 @@ def search(request, q=None, return_context=False, per_page=30):
     selected = {key: value for key, value in list(selected.items()) if value}
 
     # Dynamic title
-    beat_subtype_nouns = {
-        "release": "Releases",
-        "til": "TILs",
-        "til_update": "TIL updates",
-        "research": "Research",
-        "tool": "Tools",
-        "museum": "Museums",
-    }
+    beat_subtype_nouns = Beat.BEAT_TYPE_PLURALS
     base_type_nouns = {
         "quotation": "Quotations",
         "blogmark": "Blogmarks",

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -2502,6 +2502,149 @@ class ImporterViewTests(TransactionTestCase):
         assert "/static/captioned-image-gallery.js" in contents
 
 
+class SightingsListingAndFeedTests(TransactionTestCase):
+    def _make_sighting(self, **overrides):
+        defaults = dict(
+            beat_type="sighting",
+            title="Side-striped palm pit viper",
+            url="https://www.inaturalist.org/observations/9687475",
+            commentary="Side-striped palm pit viper",
+            slug="sighting-208",
+            created=datetime.datetime(
+                2026, 5, 2, 10, 23, tzinfo=datetime.timezone.utc
+            ),
+            metadata={
+                "started_at": "2026-05-02T10:23:01-07:00",
+                "ended_at": "2026-05-02T10:23:01-07:00",
+                "observation_count": 1,
+                "species": [],
+                "observations": [
+                    {
+                        "uri": "https://www.inaturalist.org/observations/9687475",
+                        "common_name": "Side-striped palm pit viper",
+                        "scientific_name": "Bothriechis lateralis",
+                        "photos": [
+                            {
+                                "small_url": "https://example.com/photos/1/small.jpg",
+                                "large_url": "https://example.com/photos/1/large.jpg",
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        defaults.update(overrides)
+        return BeatFactory(**defaults)
+
+    def test_sightings_listing_page_title_is_sightings(self):
+        self._make_sighting()
+        response = self.client.get("/elsewhere/sighting/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Sightings", response.context["title"])
+        self.assertContains(response, "<title>Sightings</title>")
+        self.assertContains(response, "<h2>Sightings</h2>")
+
+    def test_sightings_atom_feed_title_is_plural(self):
+        self._make_sighting()
+        response = self.client.get("/atom/beats/sighting/")
+        self.assertEqual(response.status_code, 200)
+        root = ET.fromstring(response.content)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        title = root.find("atom:title", ns).text
+        self.assertEqual(title, "Simon Willison's Weblog: Sightings")
+
+    def test_sightings_atom_feed_links_to_sighting_page(self):
+        beat = self._make_sighting()
+        response = self.client.get("/atom/beats/sighting/")
+        self.assertEqual(response.status_code, 200)
+        root = ET.fromstring(response.content)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        entry = root.find("atom:entry", ns)
+        link = entry.find("atom:link", ns).get("href")
+        self.assertTrue(
+            link.startswith("https://simonwillison.net" + beat.get_absolute_url()),
+            link,
+        )
+        # And not the external iNaturalist URL
+        self.assertNotIn("inaturalist.org", link)
+
+    def test_sightings_atom_feed_embeds_images(self):
+        self._make_sighting()
+        response = self.client.get("/atom/beats/sighting/")
+        self.assertEqual(response.status_code, 200)
+        root = ET.fromstring(response.content)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        summary = root.find("atom:entry", ns).find("atom:summary", ns).text
+        self.assertIn(
+            "https://example.com/photos/1/large.jpg", summary
+        )
+        self.assertIn("<img", summary)
+
+    def test_combined_beats_feed_links_sighting_to_sighting_page(self):
+        """The /atom/beats/ feed should also link sightings to their sighting page."""
+        beat = self._make_sighting()
+        response = self.client.get("/atom/beats/")
+        self.assertEqual(response.status_code, 200)
+        root = ET.fromstring(response.content)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        entry = root.find("atom:entry", ns)
+        link = entry.find("atom:link", ns).get("href")
+        self.assertIn(beat.get_absolute_url(), link)
+        self.assertNotIn("inaturalist.org", link)
+
+    def test_combined_beats_feed_non_sighting_still_links_external(self):
+        """Non-sighting beats in /atom/beats/ should still use the external URL."""
+        BeatFactory(
+            beat_type="release",
+            title="llm-anthropic 0.24",
+            url="https://github.com/simonw/llm-anthropic/releases/tag/0.24",
+        )
+        response = self.client.get("/atom/beats/")
+        self.assertEqual(response.status_code, 200)
+        root = ET.fromstring(response.content)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        entry = root.find("atom:entry", ns)
+        link = entry.find("atom:link", ns).get("href")
+        self.assertEqual(
+            link,
+            "https://github.com/simonw/llm-anthropic/releases/tag/0.24",
+        )
+
+    def test_everything_feed_excludes_sightings_without_notes(self):
+        """Sightings without a note must not appear in /atom/everything/."""
+        # Need a non-beat item so the feed isn't empty
+        EntryFactory(title="An entry")
+        self._make_sighting(note="")
+        response = self.client.get("/atom/everything/")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Side-striped palm pit viper")
+
+    def test_everything_feed_includes_sightings_with_notes(self):
+        """Sightings with a note should appear in /atom/everything/ rendered
+        with embedded images and a link to the sighting page."""
+        EntryFactory(title="An entry")
+        beat = self._make_sighting(note="Found this beautiful snake on a hike.")
+        response = self.client.get("/atom/everything/")
+        self.assertEqual(response.status_code, 200)
+        root = ET.fromstring(response.content)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        entries = root.findall("atom:entry", ns)
+        sighting_entry = next(
+            e for e in entries
+            if "sighting" in (e.find("atom:link", ns).get("href") or "")
+        )
+        link = sighting_entry.find("atom:link", ns).get("href")
+        # Link to the sighting page, not the iNaturalist URL
+        self.assertIn(beat.get_absolute_url(), link)
+        self.assertNotIn("inaturalist.org", link)
+        # Embedded image
+        summary = sighting_entry.find("atom:summary", ns).text
+        self.assertIn("https://example.com/photos/1/large.jpg", summary)
+        self.assertIn("<img", summary)
+        # The note is also rendered
+        self.assertIn("Found this beautiful snake", summary)
+
+
 class SponsorMessageTests(TransactionTestCase):
     def test_no_sponsor_message_no_banner(self):
         EntryFactory()

--- a/templates/feeds/everything.html
+++ b/templates/feeds/everything.html
@@ -16,8 +16,12 @@
         <p>Tags: {% for tag in obj.tags.all %}<a href="https://simonwillison.net/tags/{{ tag.tag }}">{{ tag.tag }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</p>
     {% endif %}
 {% elif obj.is_beat %}
-    <p><strong>{{ obj.get_beat_type_display }}:</strong> <a href="{{ obj.url }}">{{ obj.title }}</a></p>
-    {% if obj.note %}{{ obj.note_rendered }}{% endif %}
+    {% if obj.beat_type == "sighting" %}
+        {{ obj.sighting_feed_html }}
+    {% else %}
+        <p><strong>{{ obj.get_beat_type_display }}:</strong> <a href="{{ obj.url }}">{{ obj.title }}</a></p>
+        {% if obj.note %}{{ obj.note_rendered }}{% endif %}
+    {% endif %}
     {% if obj.tags.count %}
         <p>Tags: {% for tag in obj.tags.all %}<a href="https://simonwillison.net/tags/{{ tag.tag }}">{{ tag.tag }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}</p>
     {% endif %}


### PR DESCRIPTION
- /elsewhere/sighting/ now displays "Sightings" (was "Elsewhere") via a
  shared BEAT_TYPE_PLURALS map on the Beat model, also reused by feeds.
- /atom/beats/sighting/ feed title is now "Sightings" not "Sighting".
- Sighting entries in /atom/beats/ and /atom/beats/sighting/ embed the
  observation photos in the summary and link the entry back to the local
  sighting page (e.g. /2026/May/2/sighting-208/) instead of iNaturalist.
- /atom/everything/ continues to exclude sightings without notes; when a
  sighting does have a note it's rendered with the same embedded-photo
  display via the new Beat.sighting_feed_html method.

https://claude.ai/code/session_018CLLDeHNykeKaCbDauGALE