### PR TITLE
Use original_dimensions for sighting gallery to prevent layout shift

### DIFF
--- a/blog/importers.py
+++ b/blog/importers.py
@@ -240,10 +240,12 @@ def import_tools(url):
 
 
 def _sighting_photo(photo):
-    """Reduce an iNaturalist photo dict to {small_url, large_url}.
+    """Reduce an iNaturalist photo dict to the fields the gallery needs.
 
     The clumps.json `thumbnail_url` is actually the medium variant; replace
-    `/medium.<ext>` with `/small.<ext>` for the grid thumbnail.
+    `/medium.<ext>` with `/small.<ext>` for the grid thumbnail. When the
+    source includes `original_dimensions`, store width/height too so the
+    gallery can lay out without waiting for image loads.
     """
     thumbnail_url = photo.get("thumbnail_url") or ""
     large_url = photo.get("large_url") or thumbnail_url
@@ -253,7 +255,14 @@ def _sighting_photo(photo):
         thumbnail_url,
         flags=re.IGNORECASE,
     )
-    return {"small_url": small_url or thumbnail_url, "large_url": large_url}
+    result = {"small_url": small_url or thumbnail_url, "large_url": large_url}
+    dimensions = photo.get("original_dimensions") or {}
+    width = dimensions.get("width")
+    height = dimensions.get("height")
+    if width and height:
+        result["width"] = width
+        result["height"] = height
+    return result
 
 
 def _species_name(taxon, fallback=""):

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -2281,6 +2281,10 @@ class ImporterViewTests(TransactionTestCase):
                                 {
                                     "thumbnail_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/13245173/medium.jpg",
                                     "large_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/13245173/large.jpg",
+                                    "original_dimensions": {
+                                        "width": 2048,
+                                        "height": 1152,
+                                    },
                                 }
                             ],
                         }
@@ -2375,12 +2379,20 @@ class ImporterViewTests(TransactionTestCase):
         # small_url derived from thumbnail_url by replacing /medium.jpg -> /small.jpg
         assert photo["small_url"].endswith("/small.jpg")
         assert photo["large_url"].endswith("/large.jpg")
+        # original_dimensions is captured so the gallery can lay out without
+        # waiting for image loads
+        assert photo["width"] == 2048
+        assert photo["height"] == 1152
 
         beat2 = Beat.objects.get(import_ref="sighting:2")
         # Multi-species commentary, no observation count
         assert "Common newt" in beat2.commentary
         assert "Mallard" in beat2.commentary
         assert "observation" not in beat2.commentary.lower()
+        # Photos without original_dimensions don't gain width/height keys
+        photo2 = beat2.metadata["observations"][0]["photos"][0]
+        assert "width" not in photo2
+        assert "height" not in photo2
 
     def test_api_run_importer_sightings_skips_unchanged(self):
         from unittest.mock import patch, MagicMock
@@ -2430,7 +2442,13 @@ class ImporterViewTests(TransactionTestCase):
                             {
                                 "small_url": "https://example.com/photos/13245173/small.jpg",
                                 "large_url": "https://example.com/photos/13245173/large.jpg",
-                            }
+                                "width": 2048,
+                                "height": 1152,
+                            },
+                            {
+                                "small_url": "https://example.com/photos/13245174/small.jpg",
+                                "large_url": "https://example.com/photos/13245174/large.jpg",
+                            },
                         ],
                     }
                 ],
@@ -2446,6 +2464,12 @@ class ImporterViewTests(TransactionTestCase):
         # figcaption with link to the observation
         assert "https://www.inaturalist.org/observations/9687475" in html
         assert 'class="beat-label sighting"' in html
+        # Photos with dimensions emit data-width / data-height so the gallery
+        # can lay out without waiting for image loads
+        assert 'data-width="2048"' in html
+        assert 'data-height="1152"' in html
+        # Photos without dimensions don't get the attributes
+        assert 'src="https://example.com/photos/13245174/small.jpg" alt="Side-striped palm pit viper" loading="lazy">' in html
 
     def test_sighting_time_range_same_time(self):
         from blog.factories import BeatFactory

--- a/static/captioned-image-gallery.js
+++ b/static/captioned-image-gallery.js
@@ -264,16 +264,13 @@ class CaptionedImageGallery extends HTMLElement {
       }
     });
 
-    // Layout once images have natural dimensions available, then keep
-    // it in sync with container width changes
+    // Lay out as soon as we know an aspect ratio for every figure. When
+    // each img carries data-width / data-height we can do this synchronously
+    // and avoid the layout shift that comes from waiting on image loads.
     const imgs = this.figures.map(f => f.querySelector('img')).filter(Boolean);
-    Promise.all(imgs.map(img => {
-      if (img.complete && img.naturalWidth > 0) return Promise.resolve();
-      return new Promise(res => {
-        img.addEventListener('load', res, { once: true });
-        img.addEventListener('error', res, { once: true });
-      });
-    })).then(() => {
+    const ready = this.figures.every(f => this.declaredRatio(f) !== null);
+
+    const setup = () => {
       this.applyLayout();
       this._lastWidth = this.clientWidth;
       this._ro = new ResizeObserver(entries => {
@@ -284,7 +281,19 @@ class CaptionedImageGallery extends HTMLElement {
         }
       });
       this._ro.observe(this);
-    });
+    };
+
+    if (ready) {
+      setup();
+    } else {
+      Promise.all(imgs.map(img => {
+        if (img.complete && img.naturalWidth > 0) return Promise.resolve();
+        return new Promise(res => {
+          img.addEventListener('load', res, { once: true });
+          img.addEventListener('error', res, { once: true });
+        });
+      })).then(setup);
+    }
   }
 
   disconnectedCallback() {
@@ -292,7 +301,18 @@ class CaptionedImageGallery extends HTMLElement {
     CaptionedImageGallery.instances.delete(this);
   }
 
+  declaredRatio(figure) {
+    const img = figure.querySelector('img');
+    if (!img) return null;
+    const w = parseFloat(img.dataset.width);
+    const h = parseFloat(img.dataset.height);
+    if (isFinite(w) && isFinite(h) && w > 0 && h > 0) return w / h;
+    return null;
+  }
+
   ratioOf(figure) {
+    const declared = this.declaredRatio(figure);
+    if (declared !== null) return declared;
     const img = figure.querySelector('img');
     if (!img) return 1;
     const r = img.naturalWidth / img.naturalHeight;

--- a/templates/beat.html
+++ b/templates/beat.html
@@ -23,7 +23,7 @@
     {% if beat.commentary %}<span class="beat-commit">&mdash; {{ beat.commentary }}</span>{% endif %}
   </div>
   <captioned-image-gallery>
-    {% for obs in beat.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
+    {% for obs in beat.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"{% if photo.width and photo.height %} data-width="{{ photo.width }}" data-height="{{ photo.height }}"{% endif %}></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
   </captioned-image-gallery>
 {% if beat.note %}<div class="beat-note blogmark-body">{{ beat.note_rendered }}</div>{% endif %}
 </div>

--- a/templates/includes/blog_mixed_list.html
+++ b/templates/includes/blog_mixed_list.html
@@ -76,7 +76,7 @@
       {% if item.obj.commentary %}<span class="beat-commit">&mdash; {{ item.obj.commentary }}</span>{% endif %}
     </div>
     <captioned-image-gallery>
-      {% for obs in item.obj.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
+      {% for obs in item.obj.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"{% if photo.width and photo.height %} data-width="{{ photo.width }}" data-height="{{ photo.height }}"{% endif %}></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
     </captioned-image-gallery>
     <div class="beat-meta beat-row2">
       <a href="{{ item.obj.get_absolute_url }}" rel="bookmark">{{ item.obj.created|date:"jS M Y" }}</a>{% if all_tags %} &middot; {% for tag in all_tags %}{{ tag.get_link }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}


### PR DESCRIPTION
> Look at last few commits to learn about the new image gallery component
> 
> It suffers from a visible layout shift because it only has access to the image width and height once those images have loaded
> 
> The underlying data source JSON now includes the original width and height - update the fetching importer code to record those as well in the metadata JSON
> 
> then consider if this information can help fix that layout shift, by including it as data-attributes on the images in the HTML in the component t and then having the component use that information, if it is available

The captioned-image-gallery component sized each figure from
img.naturalWidth / naturalHeight, which is only available after the
image loads. That caused a visible reflow as thumbnails arrived.

iNaturalist clumps.json now includes an `original_dimensions` field on
each photo. The sightings importer captures it as `width` / `height` on
the photo metadata, the templates emit it as `data-width` /
`data-height` on each `<img>`, and the component prefers those values for
ratio calculations. When every figure has declared dimensions the
component lays out synchronously instead of waiting for image loads.

https://claude.ai/code/session_018CLLDeHNykeKaCbDauGALE