### PR TITLE
Add S3 upload button to blog admin forms

### DIFF
--- a/templates/admin/blog/_s3_upload_button.html
+++ b/templates/admin/blog/_s3_upload_button.html
@@ -18,7 +18,7 @@
         var textarea = document.getElementById('id_{{ field }}');
         if (!btn || !textarea) return;
         textarea.insertAdjacentElement('afterend', btn);
-        btn.style.display = '';
+        btn.style.display = 'block';
     }
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', placeButton);

--- a/templates/admin/blog/_s3_upload_button.html
+++ b/templates/admin/blog/_s3_upload_button.html
@@ -1,0 +1,29 @@
+<script type="module" src="https://simonw.github.io/s3-web-manager/assets/s3-upload-button.js"></script>
+
+<s3-upload-button
+    data-target-textarea-id="id_{{ field }}"
+    api-base-url="/tools/s3/api"
+    public-url-base="https://static.simonwillison.net/"
+    on-upload-input="textarea#id_{{ field }}"
+    input-format="markdown"
+    path="static/{date}/"
+    style="display: none; margin-top: 8px;"></s3-upload-button>
+
+<script>
+(function () {
+    function placeButton() {
+        var btn = document.querySelector(
+            's3-upload-button[data-target-textarea-id="id_{{ field }}"]'
+        );
+        var textarea = document.getElementById('id_{{ field }}');
+        if (!btn || !textarea) return;
+        textarea.insertAdjacentElement('afterend', btn);
+        btn.style.display = '';
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', placeButton);
+    } else {
+        placeButton();
+    }
+})();
+</script>

--- a/templates/admin/blog/blogmark/change_form.html
+++ b/templates/admin/blog/blogmark/change_form.html
@@ -1,0 +1,5 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+{% include "admin/blog/_s3_upload_button.html" with field="commentary" %}
+{% endblock %}

--- a/templates/admin/blog/liveupdate/change_form.html
+++ b/templates/admin/blog/liveupdate/change_form.html
@@ -1,0 +1,5 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+{% include "admin/blog/_s3_upload_button.html" with field="content" %}
+{% endblock %}

--- a/templates/admin/blog/note/change_form.html
+++ b/templates/admin/blog/note/change_form.html
@@ -1,0 +1,5 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+{% include "admin/blog/_s3_upload_button.html" with field="body" %}
+{% endblock %}


### PR DESCRIPTION
## Summary
Adds an S3 upload button widget to the Django admin forms for blog-related models, allowing direct file uploads to S3 from the admin interface.

## Changes
- **New reusable S3 upload button template** (`_s3_upload_button.html`): A shared component that integrates the `s3-upload-button` web component with dynamic field targeting and automatic button placement
- **Blog model admin customizations**: Extended admin change forms for three blog models:
  - `Blogmark`: Adds upload button to the `commentary` field
  - `LiveUpdate`: Adds upload button to the `content` field
  - `Note`: Adds upload button to the `body` field

## Implementation Details
- The S3 upload button is configured to:
  - Use `/tools/s3/api` as the API endpoint
  - Upload to `https://static.simonwillison.net/` with date-based path organization
  - Insert markdown-formatted image links directly into the target textarea
  - Dynamically position itself after the associated textarea field
- Uses a self-executing function to handle both early and late DOM readiness scenarios
- The template is parameterized to support different field names across models

https://claude.ai/code/session_01Qd5HduBonym2myFE99mYHL