### PR TITLE
Fix Cloudflare cache purge and add purge button to /admin/

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -3789,3 +3789,53 @@ class FirstThreeParagraphsTests(TransactionTestCase):
         result = str(first_three_paragraphs(html))
         self.assertNotIn("<p>Four</p>", result)
         self.assertEqual(result.count("<p>"), 3)
+
+
+class CloudflarePurgeTests(TransactionTestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser("admin", "a@b.com", "password")
+
+    def test_admin_purge_requires_login(self):
+        response = self.client.post("/admin/purge-cache/")
+        assert response.status_code == 302
+        assert "/admin/login/" in response["Location"]
+
+    def test_admin_purge_requires_post(self):
+        self.client.login(username="admin", password="password")
+        response = self.client.get("/admin/purge-cache/")
+        assert response.status_code == 405
+
+    def test_admin_purge_calls_sdk_and_flashes_success(self):
+        from unittest.mock import patch
+
+        self.client.login(username="admin", password="password")
+        with patch("blog.views.Cloudflare") as mock_cf, self.settings(
+            CLOUDFLARE_API_TOKEN="t0ken", CLOUDFLARE_ZONE_ID="zone123"
+        ):
+            response = self.client.post("/admin/purge-cache/", follow=False)
+            mock_cf.assert_called_once_with(api_token="t0ken")
+            mock_cf.return_value.cache.purge.assert_called_once_with(
+                zone_id="zone123", purge_everything=True
+            )
+        assert response.status_code == 301
+        assert response["Location"] == "/admin/"
+        # Follow the redirect and check the flash message rendered
+        response = self.client.get("/admin/")
+        self.assertContains(response, "Cloudflare cache purged")
+
+    def test_admin_purge_flashes_error_on_sdk_failure(self):
+        from unittest.mock import patch
+        from cloudflare import CloudflareError
+
+        self.client.login(username="admin", password="password")
+        with patch("blog.views.Cloudflare") as mock_cf:
+            mock_cf.return_value.cache.purge.side_effect = CloudflareError("boom")
+            self.client.post("/admin/purge-cache/")
+            response = self.client.get("/admin/")
+        self.assertContains(response, "Cloudflare cache purge failed: boom")
+
+    def test_admin_index_renders_purge_button(self):
+        self.client.login(username="admin", password="password")
+        response = self.client.get("/admin/")
+        self.assertContains(response, "Purge Cloudflare cache")
+        self.assertContains(response, "/admin/purge-cache/")

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,6 +1,7 @@
 # coding=utf8
 from django.shortcuts import render, get_object_or_404
 from django.http import JsonResponse
+from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.views.decorators.http import require_POST
 from django.views.decorators.cache import never_cache
@@ -37,7 +38,7 @@ from bs4 import BeautifulSoup as Soup
 import datetime
 import random
 from collections import Counter
-import cloudflare
+from cloudflare import Cloudflare, CloudflareError
 import os
 import pytz
 
@@ -812,17 +813,23 @@ def write(request):
     return render(request, "write.html")
 
 
+def _purge_cloudflare_cache():
+    client = Cloudflare(api_token=settings.CLOUDFLARE_API_TOKEN)
+    client.cache.purge(
+        zone_id=settings.CLOUDFLARE_ZONE_ID, purge_everything=True
+    )
+
+
 @never_cache
 @staff_member_required
 def tools(request):
     if request.POST.get("purge_all"):
-        cf = cloudflare.CloudFlare(
-            email=settings.CLOUDFLARE_EMAIL, token=settings.CLOUDFLARE_TOKEN
-        )
-        cf.zones.purge_cache.delete(
-            settings.CLOUDFLARE_ZONE_ID, data={"purge_everything": True}
-        )
-        return Redirect(request.path + "?msg=Cache+purged")
+        try:
+            _purge_cloudflare_cache()
+            msg = "Cache purged"
+        except CloudflareError as e:
+            msg = "Cache purge failed: %s" % e
+        return Redirect(request.path + "?" + urlencode({"msg": msg}))
     return render(
         request,
         "tools.html",
@@ -831,6 +838,18 @@ def tools(request):
             "deployed_hash": os.environ.get("HEROKU_SLUG_COMMIT"),
         },
     )
+
+
+@never_cache
+@require_POST
+@staff_member_required
+def admin_purge_cache(request):
+    try:
+        _purge_cloudflare_cache()
+        messages.success(request, "Cloudflare cache purged")
+    except CloudflareError as e:
+        messages.error(request, "Cloudflare cache purge failed: %s" % e)
+    return Redirect("/admin/")
 
 
 @never_cache

--- a/config/settings.py
+++ b/config/settings.py
@@ -28,8 +28,7 @@ STAGING = bool(os.environ.get("STAGING"))
 DASHBOARD_ROW_LIMIT = 200
 
 # Cloudflare details
-CLOUDFLARE_EMAIL = os.environ.get("CLOUDFLARE_EMAIL", "")
-CLOUDFLARE_TOKEN = os.environ.get("CLOUDFLARE_TOKEN", "")
+CLOUDFLARE_API_TOKEN = os.environ.get("CLOUDFLARE_API_TOKEN", "")
 CLOUDFLARE_ZONE_ID = os.environ.get("CLOUDFLARE_ZONE_ID", "")
 
 # https://github.com/simonw/simonwillisonblog/issues/498

--- a/config/urls.py
+++ b/config/urls.py
@@ -205,6 +205,11 @@ urlpatterns = [
     path("admin/bulk-tag/", blog_views.bulk_tag, name="bulk_tag"),
     path("admin/merge-tags/", blog_views.merge_tags, name="merge_tags"),
     path("admin/importers/", blog_views.importers, name="importers"),
+    path(
+        "admin/purge-cache/",
+        blog_views.admin_purge_cache,
+        name="admin_purge_cache",
+    ),
     path("api/add-tag/", blog_views.api_add_tag, name="api_add_tag"),
     path("api/run-importer/", blog_views.api_run_importer, name="api_run_importer"),
     re_path(r"^admin/", admin.site.urls),

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -27,6 +27,13 @@
                   Show "Edit" links on public pages
               </label>
           </li>
+          <li style="margin-bottom: 8px; list-style: none;">
+              <form action="{% url 'admin_purge_cache' %}" method="POST" style="display: inline;" onsubmit="return confirm('Purge the entire Cloudflare cache?');">
+                  {% csrf_token %}
+                  <button type="submit" style="cursor: pointer;">Purge Cloudflare cache</button>
+              </form>
+              - Evict every cached asset on the Cloudflare zone
+          </li>
       </ul>
   </div>
 </div>


### PR DESCRIPTION
The /tools/ purge button has been broken since the cloudflare package
was upgraded to v4 - the old v2 API (cloudflare.CloudFlare with email
and token kwargs, cf.zones.purge_cache.delete) no longer exists in
the rewritten SDK, so the POST handler raised AttributeError.

- Port to the v4 SDK: cloudflare.Cloudflare(api_token=...).cache.purge(
  zone_id=..., purge_everything=True)
- Swap CLOUDFLARE_EMAIL / CLOUDFLARE_TOKEN for a single
  CLOUDFLARE_API_TOKEN env var (Cloudflare is deprecating the email +
  Global API Key combo)
- Wrap the SDK call in try/except CloudflareError so bad configs flash
  a message instead of 500ing
- Add /admin/purge-cache/ endpoint and an inline POST form with a JS
  confirm prompt at the bottom of the admin index Tools list
- Add tests covering auth, method, success, failure and the rendered
  button