### PR TITLE
Render sighting beat notes in homepage/timeline list

### DIFF
--- a/blog/tests.py
+++ b/blog/tests.py
@@ -1723,6 +1723,23 @@ class BeatTests(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Detail Beat")
 
+    def test_sighting_beat_note_on_homepage(self):
+        """Sighting beat note should be rendered on the homepage timeline."""
+        beat = BeatFactory(
+            title="Sighting Note Beat",
+            beat_type="sighting",
+            commentary="Mallard",
+            note="A unique sighting note for the homepage test.",
+            metadata={
+                "started_at": "2025-07-15T09:15:00-07:00",
+                "ended_at": "2025-07-15T09:15:00-07:00",
+                "observations": [],
+            },
+        )
+        response = self.client.get("/")
+        self.assertContains(response, "A unique sighting note for the homepage test.")
+        self.assertContains(response, 'class="beat-note blogmark-body"')
+
     def test_beat_draft_not_on_homepage(self):
         """Draft beats should not appear on the homepage."""
         beat = BeatFactory(title="draftbeat", beat_type="release", is_draft=True)

--- a/templates/includes/blog_mixed_list.html
+++ b/templates/includes/blog_mixed_list.html
@@ -78,6 +78,7 @@
     <captioned-image-gallery>
       {% for obs in item.obj.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"{% if photo.width and photo.height %} data-width="{{ photo.width }}" data-height="{{ photo.height }}"{% endif %}></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
     </captioned-image-gallery>
+    {% if item.obj.note %}<div class="beat-note blogmark-body">{{ item.obj.note_rendered }}</div>{% endif %}
     <div class="beat-meta beat-row2">
       <a href="{{ item.obj.get_absolute_url }}" rel="bookmark">{{ item.obj.created|date:"jS M Y" }}</a>{% if all_tags %} &middot; {% for tag in all_tags %}{{ tag.get_link }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endif %}
     </div>


### PR DESCRIPTION
> Use curl to investigate - the sighting on https://simonwillison.net/2026/May/18/sighting-362781627/ has a note but the same sighting on the https://simonwillison.net/ homepage does not

The sighting branch in templates/includes/blog_mixed_list.html was missing
the beat-note rendering that the detail page (templates/beat.html) and the
non-sighting beat branch both include, so sighting notes only showed up on
the dedicated page.