### PR TITLE
Use large image variant for single-photo sighting thumbnails

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -653,6 +653,13 @@ class Beat(BaseModel):
             e.strftime("%-I:%M %p"),
         )
 
+    def sighting_photo_count(self):
+        """Total number of photos across all observations in this sighting."""
+        count = 0
+        for obs in (self.metadata or {}).get("observations") or []:
+            count += len(obs.get("photos") or [])
+        return count
+
     def index_components(self):
         return {
             "A": self.title,

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -2504,6 +2504,52 @@ class ImporterViewTests(TransactionTestCase):
             in html
         )
 
+    def test_single_photo_sighting_uses_large_url_for_thumbnail(self):
+        """A sighting with exactly one photo renders the large variant as the
+        <img src> so the enlarged single-image layout is not upscaled; the
+        thumbnail src and the lightbox <a href> are then the same file."""
+        from django.template.loader import render_to_string
+        from blog.factories import BeatFactory
+
+        beat = BeatFactory(
+            beat_type="sighting",
+            title="Surf Scoter",
+            url="https://www.inaturalist.org/observations/9687475",
+            commentary="Surf Scoter",
+            metadata={
+                "started_at": "2026-05-20T17:28:00-07:00",
+                "ended_at": "2026-05-20T17:28:00-07:00",
+                "observation_count": 1,
+                "species": [],
+                "observations": [
+                    {
+                        "uri": "https://www.inaturalist.org/observations/9687475",
+                        "common_name": "Surf Scoter",
+                        "scientific_name": "Melanitta perspicillata",
+                        "photos": [
+                            {
+                                "small_url": "https://example.com/photos/1/small.jpg",
+                                "large_url": "https://example.com/photos/1/large.jpg",
+                                "width": 2048,
+                                "height": 1152,
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+        assert beat.sighting_photo_count() == 1
+        html = render_to_string(
+            "includes/blog_mixed_list.html",
+            {"items": [{"type": "beat", "obj": beat}]},
+        )
+        # Single photo: <img src> uses the large variant, not the small one
+        assert (
+            'src="https://example.com/photos/1/large.jpg" alt="Surf Scoter" loading="lazy"'
+            in html
+        )
+        assert "https://example.com/photos/1/small.jpg" not in html
+
     def test_sighting_commentary_with_location(self):
         from blog.factories import BeatFactory
 

--- a/templates/beat.html
+++ b/templates/beat.html
@@ -23,7 +23,7 @@
     {% with commit=beat.sighting_commentary_with_location %}{% if commit %}<span class="beat-commit">&mdash; {{ commit }}</span>{% endif %}{% endwith %}
   </div>
   <captioned-image-gallery>
-    {% for obs in beat.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"{% if photo.width and photo.height %} data-width="{{ photo.width }}" data-height="{{ photo.height }}"{% endif %}></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
+    {% with photo_count=beat.sighting_photo_count %}{% for obs in beat.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{% if photo_count == 1 %}{{ photo.large_url }}{% else %}{{ photo.small_url }}{% endif %}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"{% if photo.width and photo.height %} data-width="{{ photo.width }}" data-height="{{ photo.height }}"{% endif %}></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}{% endwith %}
   </captioned-image-gallery>
 {% if beat.note %}<div class="beat-note blogmark-body">{{ beat.note_rendered }}</div>{% endif %}
 </div>

--- a/templates/includes/blog_mixed_list.html
+++ b/templates/includes/blog_mixed_list.html
@@ -76,7 +76,7 @@
       {% with commit=item.obj.sighting_commentary_with_location %}{% if commit %}<span class="beat-commit">&mdash; {{ commit }}</span>{% endif %}{% endwith %}
     </div>
     <captioned-image-gallery>
-      {% for obs in item.obj.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{{ photo.small_url }}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"{% if photo.width and photo.height %} data-width="{{ photo.width }}" data-height="{{ photo.height }}"{% endif %}></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}
+      {% with photo_count=item.obj.sighting_photo_count %}{% for obs in item.obj.metadata.observations %}{% for photo in obs.photos %}<figure><a href="{{ photo.large_url }}"><img src="{% if photo_count == 1 %}{{ photo.large_url }}{% else %}{{ photo.small_url }}{% endif %}" alt="{{ obs.common_name|default:obs.scientific_name }}" loading="lazy"{% if photo.width and photo.height %} data-width="{{ photo.width }}" data-height="{{ photo.height }}"{% endif %}></a><figcaption>{% if obs.uri %}<a href="{{ obs.uri }}" title="View observation on iNaturalist">{{ obs.common_name|default:obs.scientific_name }}</a>{% else %}{{ obs.common_name|default:obs.scientific_name }}{% endif %}</figcaption></figure>{% endfor %}{% endfor %}{% endwith %}
     </captioned-image-gallery>
     {% if item.obj.note %}<div class="beat-note blogmark-body">{{ item.obj.note_rendered }}</div>{% endif %}
     <div class="beat-meta beat-row2">


### PR DESCRIPTION

<img width="1320" height="1141" alt="IMG_5084" src="https://github.com/user-attachments/assets/b2f9e22f-f784-4095-a541-81eacee00f89" />


A sighting gallery with one photo lays the image out far larger than a
grid thumbnail, so the 240px small variant was visibly upscaled. Render
the large variant as the <img src> when the sighting has exactly one
photo, which also means the thumbnail and lightbox share one cached file.

https://claude.ai/code/session_01YZJ3HUvZdNYmQZeXd9vR7a