### PR TITLE
Cache-bust iNaturalist clumps.json fetch with random query param

### DIFF
--- a/blog/importers.py
+++ b/blog/importers.py
@@ -1,5 +1,7 @@
 import re
+import secrets
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 import httpx
 import json
@@ -274,7 +276,9 @@ def _species_name(taxon, fallback=""):
 
 
 def import_sightings(url):
-    response = httpx.get(url)
+    separator = "&" if urlparse(url).query else "?"
+    fetch_url = f"{url}{separator}cb={secrets.token_hex(8)}"
+    response = httpx.get(fetch_url)
     response.raise_for_status()
     data = response.json()
     clumps = data.get("clumps") or []


### PR DESCRIPTION
> Make it so the Import iNaturalist sighting clumps feature adds ?random-number to the JSON URL that it fetches to bust any caching

raw.githubusercontent.com aggressively caches its responses, so when
the upstream clumps.json is updated the importer can pick up a stale
copy. Append a random ?cb=<hex> query parameter at fetch time to force
a fresh response on every run.

https://claude.ai/code/session_01DVAQzTznQm6FiLg3i57sZS