### PR TITLE
Add draft checkbox to importers for marking imported items

### DIFF
--- a/blog/importers.py
+++ b/blog/importers.py
@@ -39,7 +39,7 @@ def _cache_busted_url(url):
     return f"{url}{separator}cb={secrets.token_hex(8)}"
 
 
-def import_releases(url):
+def import_releases(url, is_draft=False):
     response = httpx.get(_cache_busted_url(url))
     response.raise_for_status()
     repos = response.json()
@@ -69,6 +69,7 @@ def import_releases(url):
                 created=created,
                 import_ref=import_ref,
                 commentary=description,
+                is_draft=is_draft,
             )
             items.append(beat)
             created_count += 1
@@ -76,7 +77,7 @@ def import_releases(url):
     return {"created": created_count, "skipped": skipped_count, "items": items}
 
 
-def import_research(url):
+def import_research(url, is_draft=False):
     response = httpx.get(_cache_busted_url(url))
     response.raise_for_status()
     text = response.text
@@ -126,6 +127,7 @@ def import_research(url):
             "slug": unique_slug(dir_name, created, import_ref),
             "created": created,
             "commentary": commentary,
+            "is_draft": is_draft,
         }
 
         beat, status = _create_or_update(import_ref, defaults)
@@ -146,7 +148,7 @@ def import_research(url):
     }
 
 
-def import_tils(url):
+def import_tils(url, is_draft=False):
     response = httpx.get(url)
     response.raise_for_status()
     tils = response.json()
@@ -184,6 +186,7 @@ def import_tils(url):
             "created": created,
             "commentary": commentary,
             "image_url": image_url,
+            "is_draft": is_draft,
         }
 
         beat, status = _create_or_update(import_ref, defaults)
@@ -204,7 +207,7 @@ def import_tils(url):
     }
 
 
-def import_tools(url):
+def import_tools(url, is_draft=False):
     response = httpx.get(url)
     response.raise_for_status()
     tools = response.json()
@@ -226,6 +229,7 @@ def import_tools(url):
             "slug": unique_slug(tool["slug"], created, import_ref),
             "created": created,
             "commentary": truncate(tool.get("description") or ""),
+            "is_draft": is_draft,
         }
 
         beat, status = _create_or_update(import_ref, defaults)
@@ -280,7 +284,7 @@ def _species_name(taxon, fallback=""):
     )
 
 
-def import_sightings(url):
+def import_sightings(url, is_draft=False):
     response = httpx.get(_cache_busted_url(url))
     response.raise_for_status()
     data = response.json()
@@ -356,6 +360,7 @@ def import_sightings(url):
             "created": created,
             "commentary": commentary,
             "metadata": metadata,
+            "is_draft": is_draft,
         }
 
         beat, status = _create_or_update(import_ref, defaults)
@@ -376,7 +381,7 @@ def import_sightings(url):
     }
 
 
-def import_museums(url):
+def import_museums(url, is_draft=False):
     response = httpx.get(url)
     response.raise_for_status()
     museums = json.loads(response.text)
@@ -413,6 +418,7 @@ def import_museums(url):
             "commentary": address,
             "image_url": image_url or None,
             "image_alt": image_alt or None,
+            "is_draft": is_draft,
         }
 
         beat, status = _create_or_update(import_ref, defaults)

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -2123,6 +2123,10 @@ class ImporterViewTests(TransactionTestCase):
         self.assertContains(response, "releases_cache.json")
         self.assertContains(response, "tools.json")
         self.assertContains(response, "museums.json")
+        # Each importer has a draft checkbox, unchecked by default
+        self.assertContains(response, "Mark imported items as draft")
+        self.assertContains(response, 'type="checkbox" class="draft-checkbox"')
+        self.assertNotContains(response, "checkbox\" checked")
 
     def test_api_run_importer_requires_login(self):
         response = self.client.post(
@@ -2199,6 +2203,64 @@ class ImporterViewTests(TransactionTestCase):
             "https://raw.githubusercontent.com/simonw/simonw/refs/heads/main/"
             "releases_cache.json?cb=feedfacecafebeef"
         )
+
+    def _releases_mock_response(self):
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "my-repo": {
+                "description": "First release",
+                "releases": [
+                    {
+                        "release": "1.0",
+                        "published_at": "2025-01-15T10:00:00Z",
+                        "url": "https://github.com/simonw/my-repo/releases/tag/1.0",
+                    }
+                ],
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+        return mock_response
+
+    def test_api_run_importer_defaults_to_not_draft(self):
+        from unittest.mock import patch
+        from blog.models import Beat
+
+        self.client.login(username="admin", password="password")
+        with patch(
+            "blog.importers.httpx.get", return_value=self._releases_mock_response()
+        ):
+            response = self.client.post(
+                "/api/run-importer/",
+                json.dumps({"importer": "releases"}),
+                content_type="application/json",
+            )
+        assert response.status_code == 200
+        beat = Beat.objects.get(import_ref="release:my-repo:1.0")
+        assert beat.is_draft is False
+        # Results list links each item to its admin edit page
+        data = json.loads(response.content)
+        assert "/admin/blog/beat/{}/change/".format(beat.pk) in data["items_html"]
+
+    def test_api_run_importer_marks_items_as_draft(self):
+        from unittest.mock import patch
+        from blog.models import Beat
+
+        self.client.login(username="admin", password="password")
+        with patch(
+            "blog.importers.httpx.get", return_value=self._releases_mock_response()
+        ):
+            response = self.client.post(
+                "/api/run-importer/",
+                json.dumps({"importer": "releases", "is_draft": True}),
+                content_type="application/json",
+            )
+        assert response.status_code == 200
+        beat = Beat.objects.get(import_ref="release:my-repo:1.0")
+        assert beat.is_draft is True
+        data = json.loads(response.content)
+        assert 'class="beat-label draft"' in data["items_html"]
 
     def test_api_run_importer_research(self):
         from unittest.mock import patch, MagicMock

--- a/blog/views.py
+++ b/blog/views.py
@@ -1331,6 +1331,8 @@ def api_run_importer(request):
     if importer_name not in IMPORTERS:
         return JsonResponse({"error": "Unknown importer"}, status=400)
 
+    is_draft = bool(body.get("is_draft"))
+
     importer_funcs = {
         "releases": import_releases,
         "research": import_research,
@@ -1341,7 +1343,9 @@ def api_run_importer(request):
     }
 
     try:
-        result = importer_funcs[importer_name](IMPORTERS[importer_name]["url"])
+        result = importer_funcs[importer_name](
+            IMPORTERS[importer_name]["url"], is_draft=is_draft
+        )
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=500)
 

--- a/templates/importers.html
+++ b/templates/importers.html
@@ -12,6 +12,9 @@
   <h3>{{ importer.name }}</h3>
   <p>{{ importer.description }}</p>
   <p style="font-size: 0.85em; word-break: break-all;">Source: <a href="{{ importer.url }}">{{ importer.url }}</a></p>
+  <label style="display: inline-block; margin-right: 1em;">
+    <input type="checkbox" class="draft-checkbox"> Mark imported items as draft
+  </label>
   <button class="run-import-btn" data-importer="{{ key }}" style="padding: 0.4em 1em; cursor: pointer;">Run Import</button>
   <div class="importer-status" style="margin-top: 0.5em;"></div>
   <div class="importer-results" style="margin-top: 0.5em;"></div>
@@ -27,6 +30,7 @@ document.querySelectorAll('.run-import-btn').forEach(function(btn) {
     var section = btn.closest('.importer-section');
     var statusEl = section.querySelector('.importer-status');
     var resultsEl = section.querySelector('.importer-results');
+    var draftCheckbox = section.querySelector('.draft-checkbox');
 
     btn.disabled = true;
     btn.textContent = 'Running...';
@@ -39,7 +43,7 @@ document.querySelectorAll('.run-import-btn').forEach(function(btn) {
         'Content-Type': 'application/json',
         'X-CSRFToken': document.cookie.match(/csrftoken=([^;]+)/)[1]
       },
-      body: JSON.stringify({importer: importer})
+      body: JSON.stringify({importer: importer, is_draft: draftCheckbox.checked})
     })
     .then(function(response) { return response.json().then(function(data) { return {ok: response.ok, data: data}; }); })
     .then(function(result) {

--- a/templates/includes/importer_results.html
+++ b/templates/includes/importer_results.html
@@ -17,10 +17,12 @@
       <span class="beat-label sighting">Sighting</span>
     {% endif %}
     <span class="beat-title"><a href="{{ item.url }}">{{ item.title }}</a></span>
+    {% if item.is_draft %}<span class="beat-label draft">draft</span>{% endif %}
     {% if item.commentary %}<span class="beat-commit">&mdash; {{ item.commentary }}</span>{% endif %}
   </div>
   <div class="beat-meta beat-row2">
     <a href="{{ item.get_absolute_url }}" rel="bookmark">{{ item.created|date:"jS M Y" }}, {{ item.created|date:"f A"|lower }}</a>
+    &middot; <a href="{% url 'admin:blog_beat_change' item.pk %}">Edit in admin</a>
   </div>
 </div>
 {% endfor %}


### PR DESCRIPTION
> On admin/importers I want checkboxes next to each option for if the imported items should be marked draft or not, default to unchecked
>
> When the list of imported items is shown (in either draft or not draft) each one should link to the corresponding admin edit page

https://claude.ai/code/session_01SfumrRc4mbg9RkwDLsztW3

<details><summary>Claude Code for web Opus 4.8 High</summary>

## Summary

This PR adds the ability to mark imported items as drafts when running importers. A checkbox is now displayed on the importers page that allows users to toggle whether newly imported items should be created with `is_draft=True`.

## Key Changes

- **Templates**: Added a "Mark imported items as draft" checkbox to the importers page (`importers.html`) that is unchecked by default
- **JavaScript**: Updated the importer run button handler to capture the checkbox state and pass `is_draft` parameter to the API
- **API**: Modified `api_run_importer` view to extract the `is_draft` parameter from the request body and pass it to importer functions
- **Importers**: Updated all six importer functions (`import_releases`, `import_research`, `import_tils`, `import_tools`, `import_sightings`, `import_museums`) to accept an `is_draft` parameter and apply it when creating Beat objects
- **Results Display**: Enhanced importer results to show a "draft" label for items marked as draft and added an "Edit in admin" link for each imported item
- **Tests**: Added comprehensive test coverage including:
  - Verification that the draft checkbox appears on the importers page (unchecked by default)
  - Test confirming items default to `is_draft=False` when checkbox is unchecked
  - Test confirming items are marked as `is_draft=True` when checkbox is checked

## Implementation Details

The `is_draft` parameter flows through the entire import pipeline:
1. User checks the checkbox on the importers page
2. JavaScript captures the checkbox state and includes it in the API request
3. The view extracts the parameter and passes it to the appropriate importer function
4. Each importer applies the `is_draft` value when creating or updating Beat objects
5. Results display shows draft status and provides admin edit links for easy review

</details>