### PR TITLE
Fix sighting time range links in beat templates

### DIFF
--- a/templates/beat.html
+++ b/templates/beat.html
@@ -19,7 +19,7 @@
 <div class="beat-content">
   <div class="beat-row1">
     <a class="beat-label sighting" href="/elsewhere/{{ beat.beat_type }}/">Sighting</a>
-    <span class="beat-title"><a href="{{ beat.url }}">{{ beat.sighting_time_range }}</a></span>
+    <span class="beat-title">{{ beat.sighting_time_range }}</span>
     {% with commit=beat.sighting_commentary_with_location %}{% if commit %}<span class="beat-commit">&mdash; {{ commit }}</span>{% endif %}{% endwith %}
   </div>
   <captioned-image-gallery>

--- a/templates/includes/blog_mixed_list.html
+++ b/templates/includes/blog_mixed_list.html
@@ -72,7 +72,7 @@
   <div class="beat-content">
     <div class="beat-row1">
       <a class="beat-label sighting" href="/elsewhere/{{ item.obj.beat_type }}/">Sighting</a>
-      <span class="beat-title"><a href="{{ item.obj.url }}">{{ item.obj.sighting_time_range }}</a></span>
+      <span class="beat-title"><a href="{{ item.obj.get_absolute_url }}">{{ item.obj.sighting_time_range }}</a></span>
       {% with commit=item.obj.sighting_commentary_with_location %}{% if commit %}<span class="beat-commit">&mdash; {{ commit }}</span>{% endif %}{% endwith %}
     </div>
     <captioned-image-gallery>


### PR DESCRIPTION
> For sightings the timestamp link at the top should go to the sighting page itself,  not to iNaturalist - when the sighting is part of a list. On the sighting page itself it shouldn’t be a link at all

## Summary
Fixes inconsistent link handling for sighting time ranges in beat display templates.

## Changes
- **beat.html**: Removed the hyperlink wrapper around `beat.sighting_time_range` since the span itself doesn't need to be clickable
- **blog_mixed_list.html**: Changed `item.obj.url` to `item.obj.get_absolute_url` to use the proper Django model method for generating absolute URLs

## Details
These changes address two separate issues:
1. In `beat.html`, the sighting time range was unnecessarily wrapped in an anchor tag that pointed to `beat.url`. The text is now displayed as plain text within the span.
2. In `blog_mixed_list.html`, the template was using a direct `url` attribute instead of calling the `get_absolute_url()` method, which is the Django convention for obtaining an object's canonical URL.

https://claude.ai/code/session_01J6qyg3Vo5bm4xADv1QpMg6