### PR TITLE
Remove confirm() dialog from purge Cloudflare cache button

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -40,7 +40,7 @@ button.outline-danger:focus {
               </label>
           </li>
           <li style="margin-bottom: 8px; list-style: none;">
-              <form action="{% url 'admin_purge_cache' %}" method="POST" style="display: inline;" onsubmit="return confirm('Purge the entire Cloudflare cache?');">
+              <form action="{% url 'admin_purge_cache' %}" method="POST" style="display: inline;">
                   {% csrf_token %}
                   <button type="submit" class="outline-danger" style="cursor: pointer; background: transparent; color: #ba2121; border: 2px solid #ba2121; padding: 8px 14px; border-radius: 4px; font-weight: 600; font-size: 0.875rem;">Purge Cloudflare cache</button>
               </form>


### PR DESCRIPTION
> Weird bug on the Django admin index page in mobile safari on the iPhone - when I click the purge cache button it often freezes my browser page and fails to show the alert
>
> Research that and see if it’s a known issue
Then remove the confirm entirely

The onsubmit confirm() dialog intermittently freezes the page and fails
to display in mobile Safari on iOS, a known WebKit issue with JavaScript
dialogs. Remove the confirmation entirely.