### PR TITLE
Fix click-to-play pause button staying visible on mobile

### DIFF
--- a/static/click-to-play.css
+++ b/static/click-to-play.css
@@ -66,7 +66,17 @@ click-to-play[data-ctp-state="playing"] .ctp-i-play {
 click-to-play[data-ctp-state="playing"] .ctp-i-pause {
   display: block;
 }
-click-to-play:hover .ctp-btn {
+/* hover emphasis only on devices that truly hover — avoids sticky :hover
+   keeping the control pinned on after a tap on touchscreens */
+@media (hover: hover) {
+  click-to-play:hover .ctp-btn {
+    opacity: 1;
+    transform: scale(1.06);
+    background: rgba(12, 14, 22, 0.5);
+  }
+}
+/* touch: reveal the control briefly while/just after the finger is down */
+click-to-play.ctp-touched .ctp-btn {
   opacity: 1;
   transform: scale(1.06);
   background: rgba(12, 14, 22, 0.5);
@@ -97,7 +107,12 @@ click-to-play[data-ctp-state="loading"] .ctp-spin {
 click-to-play[data-ctp-state="playing"] .ctp-btn {
   opacity: 0;
 }
-click-to-play[data-ctp-state="playing"]:hover .ctp-btn {
+@media (hover: hover) {
+  click-to-play[data-ctp-state="playing"]:hover .ctp-btn {
+    opacity: 0.72;
+  }
+}
+click-to-play[data-ctp-state="playing"].ctp-touched .ctp-btn {
   opacity: 0.72;
 }
 click-to-play[data-ctp-state="error"] .ctp-btn {

--- a/static/click-to-play.js
+++ b/static/click-to-play.js
@@ -29,9 +29,18 @@ class ClickToPlay extends HTMLElement {
     if (!link.getAttribute("aria-label")) link.setAttribute("aria-label", "Play animation");
 
     link.addEventListener("click", this._onClick.bind(this));
+    // touchscreens have no hover, so reveal the control on touch and fade it back out
+    this.addEventListener("touchstart", this._onTouch.bind(this), { passive: true });
   }
 
   _setState(s) { this.dataset.ctpState = s; }
+
+  _onTouch() {
+    var self = this;
+    this.classList.add("ctp-touched");
+    clearTimeout(this._touchTimer);
+    this._touchTimer = setTimeout(function () { self.classList.remove("ctp-touched"); }, 1400);
+  }
 
   _onClick(e) {
     e.preventDefault();                 // hold the navigation; enhance instead


### PR DESCRIPTION
> Look at most recent commits, clone simonw/tools from GitHub to /tmp and look at last two commits there, apply that fix to the variant of that web component here

On touch devices the :hover pseudo-class sticks after a tap, so the
faint pause control stayed pinned visible once playback started. Gate
the hover emphasis behind @media (hover:hover) and add an explicit
touch-reveal (.ctp-touched) that fades the control back out after 1.4s.

Ports the fix from simonw/tools (#288) to the blog's split
CSS/JS variant of the component.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GXptDf3B7d1nkMUdLvBDTX