### PR TITLE
Restore hashed static file URLs via STORAGES setting

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -186,7 +186,15 @@ STATICFILES_DIRS = (os.path.join(BASE_DIR, "static/"),)
 
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+# STATICFILES_STORAGE was removed in Django 5.1; STORAGES is its replacement
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 
 # urls.W002


### PR DESCRIPTION
STATICFILES_STORAGE was deprecated in Django 4.2 and removed in Django
5.1, so the existing setting pointing at whitenoise's
CompressedManifestStaticFilesStorage has been silently ignored since the
Django 5.1 upgrade. Static assets were served from unversioned URLs like
/static/css/all.css with max-age=60, leaving browsers to revalidate via
304s and reuse whatever body they had cached - with no way to rescue a
client whose cache held a bad copy.

Declaring the same backend via the STORAGES setting re-enables manifest
hashing: templates now emit /static/css/all.<hash>.css served with
Cache-Control: max-age=315360000, public, immutable, and any content
change produces a brand new URL that bypasses stale browser caches.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NHTVVrwiaspZwv3mkMU5nF