### PR TITLE
Show results on /search/ when only exclude.tag is set

### DIFF
--- a/blog/search.py
+++ b/blog/search.py
@@ -322,6 +322,7 @@ def search(request, q=None, return_context=False, per_page=30):
 
     selected = {
         "tags": selected_tags,
+        "exclude_tags": excluded_tags,
         "year": selected_year,
         "month": selected_month,
         "type": selected_type,
@@ -363,6 +364,9 @@ def search(request, q=None, return_context=False, per_page=30):
 
     if selected.get("tags"):
         title += " tagged %s" % (", ".join(selected["tags"]))
+
+    if selected.get("exclude_tags"):
+        title += " excluding %s" % (", ".join(selected["exclude_tags"]))
 
     datebits = []
     if selected.get("month_name"):

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -657,6 +657,20 @@ class BlogTests(TransactionTestCase):
             "Posts tagged llm-release in July, 2025",
         )
 
+    def test_search_exclude_tag_shows_results(self):
+        tag = Tag.objects.create(tag="ai")
+        tagged = EntryFactory(title="Entry tagged with ai")
+        tagged.tags.add(tag)
+        untagged = EntryFactory(title="Entry without that tag")
+        response = self.client.get("/search/?exclude.tag=ai")
+        self.assertEqual(response.status_code, 200)
+        results = [(r["type"], r["obj"].pk) for r in response.context["results"]]
+        self.assertIn(("entry", untagged.pk), results)
+        self.assertNotIn(("entry", tagged.pk), results)
+        self.assertEqual(response.context["sort"], "date")
+        self.assertContains(response, "Entry without that tag")
+        self.assertContains(response, "Posts excluding ai")
+
     def test_quotations_feed(self):
         quotation = QuotationFactory(source="Test Source")
         response = self.client.get("/atom/quotations/")

--- a/templates/search.html
+++ b/templates/search.html
@@ -48,6 +48,10 @@
                 {% for tag in pair.1 %}
                     <input type="hidden" name="tag" value="{{ tag }}">
                 {% endfor %}
+            {% elif pair.0 == 'exclude_tags' %}
+                {% for tag in pair.1 %}
+                    <input type="hidden" name="exclude.tag" value="{{ tag }}">
+                {% endfor %}
             {% else %}
                 <input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}">
             {% endif %}
@@ -82,6 +86,9 @@
         {% endif %}
         {% for tag in selected.tags %}
             <a class="selected-tag" href="{% remove_qsarg "tag" tag %}">{{ tag }} <strong>&#x00D7;</strong></a>
+        {% endfor %}
+        {% for tag in selected.exclude_tags %}
+            <a class="selected-tag" href="{% remove_qsarg "exclude.tag" tag %}">Excluding: {{ tag }} <strong>&#x00D7;</strong></a>
         {% endfor %}
     </span>{% endif %}
     {% if results %}


### PR DESCRIPTION
> Make it so hitting https://simonwillison.net/search/?exclude.tag=ai shows results (ordered by date) - currently it doesn’t list results at all

> The UI needs to reflect when an exclude.tag=x filter has applied and allow people to click to remove that

Previously /search/?exclude.tag=ai computed the filtered queryset but
the template hid the results because excluded tags were not part of the
'selected' filters dict. Now an exclude.tag filter counts as an active
selection: results render (date-sorted by default), the exclusion shows
as a removable filter chip, the title reads 'Posts excluding ai', and
the search form preserves the exclusion via hidden inputs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NaLmVpwcKhkgH3DYE5qdc4