### PR TITLE
Remove #atom-<feed> fragments from feed item links, clean up unused `ga_source` attributes

### DIFF
--- a/blog/feeds.py
+++ b/blog/feeds.py
@@ -23,11 +23,7 @@ class Base(Feed):
         return response
 
     def item_link(self, item):
-        return (
-            "https://simonwillison.net"
-            + item.get_absolute_url()
-            + "#atom-%s" % self.ga_source
-        )
+        return "https://simonwillison.net" + item.get_absolute_url()
 
     def item_categories(self, item):
         return [t.tag for t in item.tags.all()]
@@ -46,7 +42,6 @@ class Base(Feed):
 
 class Entries(Base):
     title = "Simon Willison's Weblog: Entries"
-    ga_source = "entries"
 
     def items(self):
         return (
@@ -70,7 +65,6 @@ class Entries(Base):
 class Blogmarks(Base):
     title = "Simon Willison's Weblog: Blogmarks"
     description_template = "feeds/blogmark.html"
-    ga_source = "blogmarks"
 
     def items(self):
         return (
@@ -86,7 +80,6 @@ class Blogmarks(Base):
 class Quotations(Base):
     title = "Simon Willison's Weblog: Quotations"
     description_template = "feeds/quotation.html"
-    ga_source = "quotations"
 
     def items(self):
         return (
@@ -102,7 +95,6 @@ class Quotations(Base):
 class Notes(Base):
     title = "Simon Willison's Weblog: Notes"
     description_template = "feeds/note.html"
-    ga_source = "notes"
 
     def items(self):
         return (
@@ -120,7 +112,6 @@ class Notes(Base):
 
 class Beats(Base):
     title = "Simon Willison's Weblog: Beats"
-    ga_source = "beats"
 
     def items(self):
         return (
@@ -142,17 +133,11 @@ class Beats(Base):
 
     def item_link(self, item):
         if item.beat_type == "sighting":
-            return (
-                "https://simonwillison.net"
-                + item.get_absolute_url()
-                + "#atom-%s" % self.ga_source
-            )
+            return super().item_link(item)
         return item.url
 
 
 class BeatsByType(Beats):
-    ga_source = "beats"
-
     def get_object(self, request, beat_type):
         valid_types = {value for value, _ in Beat.BeatType.choices}
         if beat_type not in valid_types:
@@ -174,7 +159,6 @@ class BeatsByType(Beats):
 class Everything(Base):
     title = "Simon Willison's Weblog"
     description_template = "feeds/everything.html"
-    ga_source = "everything"
     include_beats = True
 
     def items(self):
@@ -247,13 +231,10 @@ class Everything(Base):
 
 class EverythingButBeats(Everything):
     title = "Simon Willison's Weblog: Everything but beats"
-    ga_source = "everything-but-beats"
     include_beats = False
 
 
 class SeriesFeed(Everything):
-    ga_source = "series"
-
     def __init__(self, series):
         self.title = "Simon Willison's Weblog: {}".format(series.title)
         self.series = series
@@ -263,8 +244,6 @@ class SeriesFeed(Everything):
 
 
 class EverythingTagged(Everything):
-    ga_source = "tag"
-
     def __init__(self, title, items):
         self.title = "Simon Willison's Weblog: {}".format(title)
         self._items = items


### PR DESCRIPTION
Hi Simon, this PR fixes #550, which is also a papercut I was running into myself when opening links to your blog from my RSS reader (NetNewsWire). It also cleans up a bit of legacy cruft.

The `#atom-everything` / `#atom-entries` / etc. fragments on feed item links were added in d66fdac (2017) as a Google Analytics mechanism: JavaScript on the site reported the originating feed as a custom dimension, then stripped the fragment from the URL bar with `history.replaceState`. When Google Analytics was removed in 99f8e02 (2024), that JavaScript went with it — so the fragments are now vestigial. Nothing consumes them, nothing strips them, and they show up in the browser and in copied/shared URLs whenever a post is opened from a feed reader.

This removes the fragment from `item_link()` and deletes the now-unused `ga_source` class attributes. Net diff: +2/−23 in `blog/feeds.py`.

---

**One tradeoff to be aware of:** these feed classes don't define `item_guid`, so Django uses the item link as the Atom `<id>`. Removing the fragment changes the ID of every current feed item, and subscribers' readers will re-show the latest ~30 posts as new items, once. If you'd rather avoid that one-time re-delivery, the alternative is to keep the historical fragment-suffixed IDs frozen via an `item_guid()` method while cleaning only the visible link.

This is the approach that Claude originally implemented, but it leaves quite a bit of ugly branching in the code and results in a bigger diff, which IMO is not worth the tradeoff. It's a one-off annoyance to have RSS readers re-download some recent posts.

---

Verification: Full test suite passes locally (325 tests).

🤖 First draft generated with [Claude Code](https://claude.com/claude-code), heavily edited by me.
