### PR TITLE
Use previous tag names when searching tags

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -199,7 +199,7 @@ class TagAdmin(admin.ModelAdmin):
         search_term = search_term.strip()
         if search_term:
             return (
-                queryset.filter(tag__istartswith=search_term)
+                queryset.search(search_term, lookup="istartswith")
                 .annotate(tag_length=Length("tag"))
                 .order_by("tag_length"),
                 False,

--- a/blog/models.py
+++ b/blog/models.py
@@ -22,9 +22,22 @@ from xml.etree import ElementTree
 tag_re = re.compile("^[a-z0-9]+$")
 
 
+class TagQuerySet(models.QuerySet):
+    def search(self, term, lookup="icontains"):
+        """Match current and previous names without duplicating tags."""
+        previous_names = PreviousTagName.objects.filter(
+            **{f"previous_name__{lookup}": term}
+        )
+        return self.filter(
+            models.Q(**{f"tag__{lookup}": term})
+            | models.Q(pk__in=previous_names.values("tag_id"))
+        )
+
+
 class Tag(models.Model):
     tag = models.SlugField(unique=True)
     description = models.TextField(blank=True)
+    objects = TagQuerySet.as_manager()
 
     def __str__(self):
         return self.tag

--- a/blog/search.py
+++ b/blog/search.py
@@ -490,8 +490,6 @@ def tools_search_tags(request):
     q = request.GET.get("q", "").strip()
     results = []
     if q:
-        results = list(
-            Tag.objects.filter(tag__icontains=q).values_list("tag", flat=True)
-        )
+        results = list(Tag.objects.search(q).values_list("tag", flat=True))
         results.sort(key=lambda t: len(t))
     return HttpResponse(json.dumps({"tags": results}), content_type="application/json")

--- a/blog/tag_views.py
+++ b/blog/tag_views.py
@@ -1,4 +1,4 @@
-from .models import Tag
+from .models import Tag, PreviousTagName
 from django.db.models import (
     Case,
     When,
@@ -65,7 +65,7 @@ def tags_autocomplete(request):
         )
 
         tags = (
-            Tag.objects.filter(tag__icontains=query)
+            Tag.objects.search(query)
             .annotate(
                 total_entry=Subquery(entry_count),
                 total_blogmark=Subquery(blogmark_count),
@@ -73,7 +73,15 @@ def tags_autocomplete(request):
                 total_note=Subquery(note_count),
                 total_beat=Subquery(beat_count),
                 is_exact_match=Case(
-                    When(tag__iexact=query, then=Value(1)),
+                    When(
+                        Q(tag__iexact=query)
+                        | Q(
+                            pk__in=PreviousTagName.objects.filter(
+                                previous_name__iexact=query
+                            ).values("tag_id")
+                        ),
+                        then=Value(1),
+                    ),
                     default=Value(0),
                     output_field=IntegerField(),
                 ),

--- a/blog/templatetags/tag_cloud.py
+++ b/blog/templatetags/tag_cloud.py
@@ -4,7 +4,7 @@ from django.utils.html import format_html
 
 register = template.Library()
 
-from blog.models import Tag
+from blog.models import PreviousTagName
 
 # Classes for different levels
 CLASSES = (
@@ -51,7 +51,8 @@ def tag_cloud_for_tags(tags):
     return _tag_cloud_helper(tags)
 
 
-def _tag_cloud_helper(tags):
+def _tag_cloud_helper(tags, previous_names=None):
+    previous_names = previous_names or {}
     # Count them all up
     tag_counts = {}
     for tag in tags:
@@ -79,11 +80,13 @@ def _tag_cloud_helper(tags):
         count_display = intcomma(score)
         html_tags.append(
             format_html(
-                '<a href="/tags/{}/" title="{} item{}" class="item-tag {}">{} <span>{}</span></a>',
+                '<a href="/tags/{}/" title="{} item{}" class="item-tag {}" '
+                'data-previous-names="{}">{} <span>{}</span></a>',
                 tag,
                 count_display,
                 "" if score == 1 else "s",
                 CLASSES[index],
+                " ".join(previous_names.get(tag, [])),
                 tag,
                 count_display,
             )
@@ -117,4 +120,9 @@ def tag_cloud():
     cursor.close()
     # Add them together
     tags = entry_tags + blogmark_tags + quotation_tags + note_tags
-    return _tag_cloud_helper(tags)
+    previous_names = {}
+    for tag, previous_name in PreviousTagName.objects.values_list(
+        "tag__tag", "previous_name"
+    ):
+        previous_names.setdefault(tag, []).append(previous_name)
+    return _tag_cloud_helper(tags, previous_names=previous_names)

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -1057,6 +1057,152 @@ class TypeListingTests(TransactionTestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class TagSearchTests(TransactionTestCase):
+    def setUp(self):
+        self.tag = Tag.objects.create(tag="python")
+        for name in ("legacy-python", "legacy-python-2", "historic"):
+            PreviousTagName.objects.create(tag=self.tag, previous_name=name)
+        Tag.objects.create(tag="ruby")
+
+    def test_public_search_matches_current_and_previous_names(self):
+        for query in ("python", "PYTH", "legacy", "ACY-PY", "historic", " legacy "):
+            with self.subTest(query=query):
+                response = self.client.get("/tags-autocomplete/", {"q": query})
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    [(tag["id"], tag["tag"]) for tag in response.json()["tags"]],
+                    [(self.tag.pk, "python")],
+                )
+                response = self.client.get("/tools/search-tags/", {"q": query})
+                self.assertEqual(response.json(), {"tags": ["python"]})
+
+    def test_public_search_empty_or_unmatched_query(self):
+        for path in ("/tags-autocomplete/", "/tools/search-tags/"):
+            for query in ("", "  ", "missing"):
+                with self.subTest(path=path, query=query):
+                    response = self.client.get(path, {"q": query})
+                    self.assertEqual(response.json(), {"tags": []})
+
+    def test_public_autocomplete_counts_are_not_multiplied_by_aliases(self):
+        for factory in (
+            EntryFactory,
+            BlogmarkFactory,
+            QuotationFactory,
+            NoteFactory,
+            BeatFactory,
+        ):
+            factory(is_draft=False).tags.add(self.tag)
+            factory(is_draft=True).tags.add(self.tag)
+
+        response = self.client.get("/tags-autocomplete/", {"q": "python"})
+        tags = response.json()["tags"]
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(tags[0]["count"], 5)
+        for content_type in ("entry", "blogmark", "quotation", "note", "beat"):
+            self.assertEqual(tags[0]["total_" + content_type], 1)
+
+    def test_exact_previous_name_is_prioritized_before_result_limit(self):
+        entry = EntryFactory()
+        for i in range(6):
+            entry.tags.add(Tag.objects.create(tag=f"legacy-python-extra-{i}"))
+
+        response = self.client.get("/tags-autocomplete/", {"q": "LEGACY-PYTHON"})
+        tags = response.json()["tags"]
+        self.assertEqual(len(tags), 5)
+        self.assertEqual(tags[0]["id"], self.tag.pk)
+        self.assertEqual(tags[0]["is_exact_match"], 1)
+
+    def test_tools_search_keeps_length_ordering(self):
+        short_tag = Tag.objects.create(tag="py")
+        PreviousTagName.objects.create(tag=short_tag, previous_name="legacy-py")
+        response = self.client.get("/tools/search-tags/", {"q": "legacy"})
+        self.assertEqual(response.json(), {"tags": ["py", "python"]})
+
+    def test_admin_autocomplete_matches_current_and_previous_prefixes(self):
+        admin = User.objects.create_superuser("admin", "a@example.com", "password")
+        self.client.force_login(admin)
+        for app_label, model in (
+            ("blog", "entry"),
+            ("blog", "blogmark"),
+            ("blog", "quotation"),
+            ("blog", "note"),
+            ("blog", "beat"),
+            ("guides", "chapter"),
+        ):
+            for query in ("py", "python", "LEGACY", "historic", " legacy "):
+                with self.subTest(model=model, query=query):
+                    response = self.client.get(
+                        "/admin/autocomplete/",
+                        {
+                            "app_label": app_label,
+                            "model_name": model,
+                            "field_name": "tags",
+                            "term": query,
+                        },
+                    )
+                    self.assertEqual(response.status_code, 200)
+                    self.assertEqual(
+                        response.json(),
+                        {
+                            "results": [{"id": str(self.tag.pk), "text": "python"}],
+                            "pagination": {"more": False},
+                        },
+                    )
+
+    def test_admin_search_preserves_queryset_and_prefix_matching(self):
+        from blog.admin import TagAdmin
+        from django.contrib import admin
+        from django.test import RequestFactory
+
+        tag_admin = TagAdmin(Tag, admin.site)
+        request = RequestFactory().get("/admin/blog/tag/")
+        short_tag = Tag.objects.create(tag="py")
+        PreviousTagName.objects.create(tag=short_tag, previous_name="legacy-py")
+
+        results, may_have_duplicates = tag_admin.get_search_results(
+            request, Tag.objects.all(), "legacy"
+        )
+        self.assertEqual(list(results), [short_tag, self.tag])
+        self.assertFalse(may_have_duplicates)
+
+        results, _ = tag_admin.get_search_results(
+            request, Tag.objects.exclude(pk=self.tag.pk), "historic"
+        )
+        self.assertFalse(results.exists())
+
+        for query in ("egacy", "missing"):
+            results, _ = tag_admin.get_search_results(request, Tag.objects.all(), query)
+            self.assertFalse(results.exists())
+
+        results, _ = tag_admin.get_search_results(request, Tag.objects.all(), "  ")
+        self.assertEqual(set(results), set(Tag.objects.all()))
+
+    def test_admin_tag_changelist_searches_previous_names(self):
+        admin = User.objects.create_superuser("admin", "a@example.com", "password")
+        self.client.force_login(admin)
+        response = self.client.get("/admin/blog/tag/", {"q": "legacy"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context["cl"].result_list), [self.tag])
+
+    def test_tag_index_includes_previous_names_for_filtering(self):
+        from bs4 import BeautifulSoup
+
+        for _ in range(2):
+            EntryFactory().tags.add(self.tag)
+        EntryFactory().tags.add(Tag.objects.get(tag="ruby"))
+
+        response = self.client.get("/tags/")
+        self.assertEqual(response.status_code, 200)
+        soup = BeautifulSoup(response.content, "html.parser")
+        tags = soup.select('#tagcloud a[href="/tags/python/"]')
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(
+            set(tags[0]["data-previous-names"].split()),
+            {"legacy-python", "legacy-python-2", "historic"},
+        )
+        self.assertEqual(tags[0].get_text(), "python 2")
+
+
 class MergeTagsTests(TransactionTestCase):
     def setUp(self):
         self.staff_user = User.objects.create_user(
@@ -1162,6 +1308,58 @@ class MergeTagsTests(TransactionTestCase):
         response = self.client.get("/tags/redirect-from/")
         self.assertEqual(response.status_code, 301)
         self.assertIn("redirect-to", response.url)
+
+    def test_previous_names_survive_repeated_merges(self):
+        source = Tag.objects.create(tag="original")
+        source.rename_tag("renamed")
+        Tag.objects.create(tag="intermediate")
+        destination = Tag.objects.create(tag="destination")
+        EntryFactory().tags.add(source)
+
+        self.staff_user.is_superuser = True
+        self.staff_user.save()
+        self.client.force_login(self.staff_user)
+        for source_name, destination_name in (
+            ("renamed", "intermediate"),
+            ("intermediate", "destination"),
+        ):
+            response = self.client.post(
+                "/admin/merge-tags/",
+                {
+                    "source": source_name,
+                    "destination": destination_name,
+                    "confirm": "yes",
+                },
+            )
+            self.assertContains(response, "Successfully merged")
+
+        for name in ("original", "renamed", "intermediate"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    PreviousTagName.objects.get(previous_name=name).tag, destination
+                )
+                response = self.client.get("/tags-autocomplete/", {"q": name})
+                self.assertEqual(
+                    [tag["tag"] for tag in response.json()["tags"]], ["destination"]
+                )
+                response = self.client.get("/tools/search-tags/", {"q": name})
+                self.assertEqual(response.json(), {"tags": ["destination"]})
+                response = self.client.get(
+                    "/admin/autocomplete/",
+                    {
+                        "app_label": "blog",
+                        "model_name": "entry",
+                        "field_name": "tags",
+                        "term": name,
+                    },
+                )
+                self.assertEqual(
+                    response.json()["results"],
+                    [{"id": str(destination.pk), "text": "destination"}],
+                )
+                response = self.client.get(f"/tags/{name}/", follow=True)
+                self.assertEqual(response.redirect_chain[-1][0], "/tags/destination/")
+                self.assertEqual(response.status_code, 200)
 
     def test_merge_creates_tag_merge_record(self):
         """Merging tags creates a TagMerge record with details."""

--- a/blog/views.py
+++ b/blog/views.py
@@ -1165,6 +1165,10 @@ def merge_tags(request):
                     note.tags.add(destination_tag)
                     details["notes"]["added"].append(note.pk)
 
+            # Preserve aliases from earlier renames and merges before deleting
+            # the source tag, which would otherwise cascade-delete them.
+            PreviousTagName.objects.filter(tag=source_tag).update(tag=destination_tag)
+
             # Create PreviousTagName for redirect
             PreviousTagName.objects.create(
                 tag=destination_tag, previous_name=source_tag.tag

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -42,7 +42,10 @@
             const tagText = tag.textContent;
 
             // Check if tag text matches the pattern (terms in order)
-            const matches = pattern.test(tagText);
+            const previousNames = (tag.dataset.previousNames || '').split(' ');
+            const matches = pattern.test(tagText) || previousNames.some(
+                name => pattern.test(name)
+            );
 
             tag.style.display = matches ? '' : 'none';
         });


### PR DESCRIPTION
> Clone simonw/simonwillisonblog from GitHub and add a feature so tags that gave been merged also show up in tag search results for their former names - and that this works for the Django admin tag autocomplete interface too 

Code by GPT-6 Astra in ChatGPT Work: https://chatgpt.com/share/6a9da3b1-7360-83e9-bbd5-7e4de129e2b5